### PR TITLE
Fixed ingame dps/hps counters

### DIFF
--- a/game/scripts/vscripts/addon_game_mode.lua
+++ b/game/scripts/vscripts/addon_game_mode.lua
@@ -6197,7 +6197,7 @@ function COverthrowGameMode:OnThink()
       end
     end
     --statistics
-    local damagepersec = 0 -- math.floor(hero.damage_done / 30) might create overflow bug, breaking saving to database
+    local damagepersec = math.floor(hero.damage_done / 30)
     if hero.best_dps then
      if damagepersec > hero.best_dps then
       hero.best_dps = damagepersec
@@ -6205,7 +6205,7 @@ function COverthrowGameMode:OnThink()
   else
    hero.best_dps = damagepersec
  end
- local healpersec = 0 -- math.floor(hero.healing_done / 30)
+ local healpersec = math.floor(hero.healing_done / 30)
  if hero.best_hps then
    if healpersec > hero.best_hps then
     hero.best_hps = healpersec
@@ -9465,9 +9465,9 @@ end
          if setHeroStatsAggroPercent then
           source.aggro_caused = final_factor
         end
-        --if source:IsRealHero() then
-        --  source.damage_done = source.damage_done + aggro_original
-        --end
+        if source:IsRealHero() then
+          source.damage_done = source.damage_done + aggro_original
+        end
       end
       caster.aggrolist[source:GetPlayerOwnerID()] = caster.aggrolist[source:GetPlayerOwnerID()] + aggro
       if caster.totalaggro then


### PR DESCRIPTION
Here i enabled dps/hps counters in game. Should be fine because you hardcoded 0 to both fields in COverthrowGameMode:SaveChar(hero) so php server overflow (or whatever it was) issue should not happen. This save data hps/dps counters also seems unused in game so nothing changed from player perspective except working counters

Dota uses Lua 5.1 (print(_VERSION) = Lua 5.1) and unless valve changed something lua before 5.3 uses double to store number values internally so integers (dps/hps) should be fine up to 100,000,000,000,000 (https://www.lua.org/pil/2.3.html)