### PR TITLE
GetDedicatedServerKeyV2 -> GetDedicatedServerKeyV3

### DIFF
--- a/game/scripts/vscripts/addon_game_mode.lua
+++ b/game/scripts/vscripts/addon_game_mode.lua
@@ -13026,7 +13026,7 @@ if hero.best_hps then
   hps = hero.best_hps
 end
 local temple_abilities = {}
-local aggro_amount = GetDedicatedServerKeyV2("GetAggroKeyVTWO") --GetDedicatedServerKey("GetAggroKey")
+local aggro_amount = GetDedicatedServerKeyV3("GetAggroKeyV3") --GetDedicatedServerKeyV2("GetAggroKeyVTWO") --GetDedicatedServerKey("GetAggroKey")
 --find keyv2
 --if tostring(steamid) == "95413522" then
   --    Notifications:Bottom(hero:GetPlayerID(), {text=GetDedicatedServerKeyV2("GetAggroKeyVTWO"), duration=8, style={color="lightgreen"}})


### PR DESCRIPTION
This should be carefully merged. 
I suggest maintain backward compatibility in php script with V2 for at least day so everyone 100% finish their run with something like that:
```
if (strcmp($keyFromRequest, $validV2KeyValue) === 0 || strcmp($keyFromRequest, $validV3KeyValue) === 0) 
{
	$saveIsValid = true;
}
```