### PR TITLE
Fixed issues with pl shield caused by previous fix

### DIFF
--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -16787,7 +16787,7 @@ function StrikeOfVengeance2( event )
 end
 
 function SanctifiedCrusaderRetaliation( event )
-    event.caster:AddNewModifier(event.caster, event.ability, "modifier_godschosen_2", {duration = event.Duration})
+    event.target:AddNewModifier(event.caster, event.ability, "modifier_godschosen_2", {duration = event.Duration})
 end
 
 function StrikeOfVengeance3( event )

--- a/game/scripts/vscripts/modifiers/heroes/sanctified_crusader/modifier_godschosen_2.lua
+++ b/game/scripts/vscripts/modifiers/heroes/sanctified_crusader/modifier_godschosen_2.lua
@@ -90,7 +90,7 @@ function modifier_godschosen_2:OnDestroy()
 		false
 	)
 
-    local finalDamage = math.min(self:GetStackCount() * self.finalDmgPct, self.parent:GetMaxHealth())
+    local finalDamage = math.min(self:GetStackCount() * self.finalDmgPct, self.parent:GetMaxHealth() * 2)
 
     for _, enemy in pairs(enemies) do
         local particle = ParticleManager:CreateParticle(


### PR DESCRIPTION
Welp... I don't tested good enough and also accidently nerfed pl on top of that. I don't think anybody would notice that nerf, but this still not fair for pl players
So this pull requests does next things:
- Shield damage now capped by 200% max health instead of 100%
- Now it applies shield modifier to ability target instead of caster

![image](https://github.com/Catzee/Titanbreaker/assets/61186758/6d8027b1-6934-4e21-97c0-3851831277d8)