### PR TITLE
Fixed broken particles

### DIFF
--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -92525,19 +92525,11 @@
 
         		"OnCreated"
         		{
-        			"AttachEffect"
-	            	{
-	            		"EffectName"        "particles/econ/items/invoker/invoker_ti6/invoker_tornado_ti6_funnel.vpcf"
-	            		"EffectAttachType"  "attach_hitloc"
-	            		"Target"            "TARGET"
-	            		"ControlPointEntities"
-	            		{
-	            			"TARGET"	"attach_hitloc"
-	            			"TARGET"	"attach_hitloc"
-	            			"TARGET"	"attach_hitloc"
-	            			"TARGET"	"attach_hitloc"
-	            		}
-	            	}
+					"RunScript"
+					{
+					    "ScriptFile"    "game_mechanics.lua"
+					    "Function"      "AddCrowTornadoParticle"
+					}
         		}
         		"ThinkInterval"  "3.5"
         		"OnIntervalThink"

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -80678,23 +80678,11 @@
         	
         		"OnCreated"
         		{
-        			"FireEffect"
-        			{
-        				"EffectName"        "particles/econ/items/legion/legion_weapon_voth_domosh/legion_duel_start_ring_rope_arcana.vpcf"
-        				"EffectAttachType"  "attach_hitloc"
-        				"Target"            "TARGET"
-        				"ControlPointEntities"
-        				{
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        				}
-        			}
+					"RunScript"
+					{
+					    "ScriptFile"    "game_mechanics.lua"
+					    "Function"      "AddPathOfFlamesRingParticle"
+					}
         		}
         	
         		"ThinkInterval"  "1.5"
@@ -80714,23 +80702,11 @@
 					    "onlyhero"	"1"
 					    "firedmg"	"1"
 					}
-					"FireEffect"
-        			{
-        				"EffectName"        "particles/econ/items/legion/legion_weapon_voth_domosh/legion_duel_start_ring_rope_arcana.vpcf"
-        				"EffectAttachType"  "attach_hitloc"
-        				"Target"            "TARGET"
-        				"ControlPointEntities"
-        				{
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        					"TARGET"	"attach_hitloc"
-        				}
-        			}
+					"RunScript"
+					{
+					    "ScriptFile"    "game_mechanics.lua"
+					    "Function"      "AddPathOfFlamesRingParticle"
+					}
         		}
         	}
 		}

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -15843,6 +15843,19 @@ function DancingRune(event)
     end)
 end
 
+function AddCrowTornadoParticle( event)
+    local dummy = event.target
+    local dummyModifier = dummy:FindModifierByName("modifier_poolfx")
+
+    if(dummyModifier == nil) then
+        return
+    end
+
+    local particle = ParticleManager:CreateParticle("particles/econ/items/invoker/invoker_ti6/invoker_tornado_ti6_funnel.vpcf", PATTACH_ABSORIGIN_FOLLOW, dummy)
+    ParticleManager:SetParticleControlEnt(particle, 3, dummy, PATTACH_ABSORIGIN_FOLLOW , "attach_hitloc", dummy:GetAbsOrigin(), true)
+    dummyModifier:AddParticle(particle, false, false, 1, false, false)
+end
+
 function DancingRuneAADamage( event )
     local caster = event.caster
     local target = event.target

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -15856,6 +15856,19 @@ function AddCrowTornadoParticle( event)
     dummyModifier:AddParticle(particle, false, false, 1, false, false)
 end
 
+function AddPathOfFlamesRingParticle( event)
+    local dummy = event.target
+    local dummyModifier = dummy:FindModifierByName("modifier_poolfx")
+
+    if(dummyModifier == nil) then
+        return
+    end
+
+    local particle = ParticleManager:CreateParticle("particles/econ/items/legion/legion_weapon_voth_domosh/legion_duel_start_ring_rope_arcana.vpcf", PATTACH_ABSORIGIN, dummy)
+    ParticleManager:SetParticleControlEnt(particle, 7, dummy, PATTACH_ABSORIGIN , "attach_hitloc", dummy:GetAbsOrigin(), true)
+    dummyModifier:AddParticle(particle, false, false, 1, false, false)
+end
+
 function DancingRuneAADamage( event )
     local caster = event.caster
     local target = event.target

--- a/game/scripts/vscripts/items.lua
+++ b/game/scripts/vscripts/items.lua
@@ -7384,7 +7384,7 @@ function COverthrowGameMode:DropTempleItem( unit, reward, drop_type, buy_quality
 										        -- Destroy & release item particle on item pickup
 												Timers:CreateTimer(1,function()
 													if(itemContainer:IsNull()) then
-														ParticleManager:DestroyParticle(particle2, false)
+														ParticleManager:DestroyParticle(particle2, true)
 														ParticleManager:ReleaseParticleIndex(particle2)
 														return
 													end
@@ -7396,7 +7396,7 @@ function COverthrowGameMode:DropTempleItem( unit, reward, drop_type, buy_quality
 										        		-- Destroy & release item particle on item pickup
 														Timers:CreateTimer(1,function()
 															if(itemContainer:IsNull()) then
-																ParticleManager:DestroyParticle(particle, false)
+																ParticleManager:DestroyParticle(particle, true)
 																ParticleManager:ReleaseParticleIndex(particle)
 																return
 															end
@@ -7408,7 +7408,7 @@ function COverthrowGameMode:DropTempleItem( unit, reward, drop_type, buy_quality
 										        			local rayParticle = ParticleManager:CreateParticle(fxpath_ray, PATTACH_POINT_FOLLOW, itemContainer)
 										        			Timers:CreateTimer(1,function()
 																if(itemContainer:IsNull()) then
-																	ParticleManager:DestroyParticle(rayParticle, false)
+																	ParticleManager:DestroyParticle(rayParticle, true)
 																	ParticleManager:ReleaseParticleIndex(rayParticle)
 																	return
 																end


### PR DESCRIPTION
Here what's changed:
- Fixed items ray particle don't disappear in time due to missing endcap animation. Now they instantly destroyed
- Fixed crow tornado particle
- Fixed molten forge fire golem boss fire ring particle

![image](https://github.com/Catzee/Titanbreaker/assets/61186758/770ed836-9ea0-4a74-a650-ecab304001ab)
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/a38c99c6-3802-483e-b369-c0ec23bb6884)