### PR TITLE
Fixed paw of moogla (hopefully finally this time)

### DIFF
--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -16049,7 +16049,7 @@
 	}
 	"Modifiers"
 	{
-		"modifier_pathbuff_006"
+		"modifier_pathbuff_005"
 		{
 			"Passive"  "1"
 	  		"IsHidden"  "1"

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -20331,7 +20331,7 @@ function PassiveStatCalculation(event)
         if hero:HasModifier("modifier_pathbuff_004") then
             primary_stats_static_bonus = primary_stats_static_bonus + 75
         end
-        if hero:HasModifier("modifier_pathbuff_006") then
+        if hero:HasModifier("modifier_pathbuff_005") then
             primary_stats_static_bonus = primary_stats_static_bonus + 100
         end
         if hero:HasModifier("modifier_pathbuff_007") then


### PR DESCRIPTION
Here i basicly reverted 3a734dbed2699bf2eecea8f502a112d120f1f069 that caused another bug because i don't tested my changes good enough... Paw of moogla (item_pathbuff_006) supposed to give +3 presence of power (talent id = 5) and +100 primary attribute so his divine (item_pathbuff_006) must provide modifier_pathbuff_005...

Effect with paw of moogla (item_pathbuff_006)
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/a0779561-667c-4705-8268-80d1a76192df)
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/28bf0a4d-323b-4b2d-bfec-c679e073b2fd)

Effect with steelskin shoulders (item_pathbuff_005)
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/abbdbb48-dd88-49ab-9184-8a852fe33f16)
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/6bf80a9a-df72-47c2-9e1c-9f1b5d25d247)