### PR TITLE
Fixed invoker abilities & talents

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -7217,17 +7217,14 @@
 		"DOTA_Tooltip_Ability_special_bonus_respawn_reduction_15"	"+ 25% Nature Damage" //tier 2/3
 		"DOTA_Tooltip_Ability_special_bonus_gold_income_5"	"+ 25% Auto Attack Crit Damage" //tier 3/4
 
-		"DOTA_Tooltip_Ability_special_bonus_unique_invoker_10"	"+ 5% Movement Speed"
-		"DOTA_Tooltip_Ability_special_bonus_unique_invoker_6"	"+ 15 All Stats"
-		"DOTA_Tooltip_Ability_special_bonus_unique_invoker_1"	"+ 5% Damage"
-		"DOTA_Tooltip_Ability_special_bonus_unique_invoker_9"	"+ 10% Cooldown Reduction"
-		"DOTA_Tooltip_Ability_special_bonus_unique_invoker_4"	"+ 500 Mana"
-		"DOTA_Tooltip_Ability_special_bonus_unique_invoker_5"	"+ 300 Cast Range"
-		"DOTA_Tooltip_Ability_special_bonus_unique_invoker_2"	"+ 35 Spell Resistance"
-		"DOTA_Tooltip_Ability_special_bonus_unique_invoker_3"	"+ 75 Intellect"
-		
-		
-		
+		"DOTA_Tooltip_Ability_special_bonus_unique_nether_wizard_1"	"+ 5% Movement Speed"
+		"DOTA_Tooltip_Ability_special_bonus_unique_nether_wizard_2"	"+ 15 All Stats"
+		"DOTA_Tooltip_Ability_special_bonus_unique_nether_wizard_3"	"+ 5% Damage"
+		"DOTA_Tooltip_Ability_special_bonus_unique_nether_wizard_4"	"+ 10% Cooldown Reduction"
+		"DOTA_Tooltip_Ability_special_bonus_unique_nether_wizard_5"	"+ 500 Mana"
+		"DOTA_Tooltip_Ability_special_bonus_unique_nether_wizard_6"	"+ 300 Cast Range"
+		"DOTA_Tooltip_Ability_special_bonus_unique_nether_wizard_7"	"+ 35 Spell Resistance"
+		"DOTA_Tooltip_Ability_special_bonus_unique_nether_wizard_8"	"+ 75 Intellect"
 
 		"DOTA_Tooltip_ability_pve_passive_as_25"                                          "Raging Claws"
 		"DOTA_Tooltip_ability_pve_passive_as_25_Description"                              "Attack Speed increased and Corruption restored on when attacking."

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -40653,8 +40653,186 @@
 			}
 	    }
 	}
-	
 
+	"special_bonus_unique_nether_wizard_1" 
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"special_bonus_undefined"
+		"AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"value"					"5"
+			}
+		}
+	}
+
+	"special_bonus_unique_nether_wizard_2" 
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"special_bonus_undefined"
+		"AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_INTEGER"
+				"bonus_move_speed"		"5"
+			}
+		}
+	}
+
+	"special_bonus_unique_nether_wizard_3" 
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"special_bonus_undefined"
+		"AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"bonus_all_stats"		"15"
+			}
+		}
+	}
+
+	"special_bonus_unique_nether_wizard_3" 
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"special_bonus_undefined"
+		"AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"bonus_damage"			"5"
+			}
+		}
+	}
+
+	"special_bonus_unique_nether_wizard_4" 
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"special_bonus_undefined"
+		"AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"bonus_cdr"				"10"
+			}
+		}
+	}
+
+	"special_bonus_unique_nether_wizard_5" 
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"special_bonus_undefined"
+		"AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"bonus_mana"			"500"
+			}
+		}
+	}
+
+	"special_bonus_unique_nether_wizard_6" 
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"special_bonus_undefined"
+		"AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"bonus_cast_range"		"300"
+			}
+		}
+	}
+
+	"special_bonus_unique_nether_wizard_7" 
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"special_bonus_undefined"
+		"AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"					"FIELD_FLOAT"
+				"bonus_spell_resistance"	"35"
+			}
+		}
+	}
+
+	"special_bonus_unique_nether_wizard_8" 
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"BaseClass"						"special_bonus_undefined"
+		"AbilityType"					"DOTA_ABILITY_TYPE_ATTRIBUTES"
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_PASSIVE"
+		
+		// Special
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilitySpecial"
+		{
+			"01"
+			{
+				"var_type"				"FIELD_FLOAT"
+				"bonus_intellect"		"75"
+			}
+		}
+	}
 	// retri Paladin
 	"Retri5"
 	{

--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -5691,16 +5691,83 @@
 		}
 	}
 
+	// Hide invoker abilities from pick screen
+	"invoker_invoke"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
+	
+	"invoker_cold_snap"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
 
+	"invoker_ghost_walk"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
 
+	"invoker_tornado"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
 
+	"invoker_emp"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
 
+	"invoker_alacrity"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
 
+	"invoker_chaos_meteor"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
 
+	"invoker_sun_strike"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
 
+	"invoker_forge_spirit"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
 
+	"invoker_ice_wall"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
 
-
+	"invoker_deafening_blast"	
+	{
+		// General
+		//-------------------------------------------------------------------------------------------------------------
+		"AbilityBehavior"				"DOTA_ABILITY_BEHAVIOR_NOT_LEARNABLE | DOTA_ABILITY_BEHAVIOR_HIDDEN"
+	}
 	//=================================================================================================================
 	// Special Item Drops
 	//=================================================================================================================

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -2418,14 +2418,15 @@
 		"Ability6"					"Arcane6"
 		"Ability7"					"combat_system"
 
-		//"Ability10"		"special_bonus_unique_invoker_1" //"special_bonus_movement_speed_25"
-		//"Ability11"		"special_bonus_unique_invoker_2" //"special_bonus_all_stats_15"
-		//"Ability12"		"special_bonus_unique_invoker_3" //"special_bonus_spell_amplify_5"
-		//"Ability13"		"special_bonus_unique_invoker_4" //"special_bonus_cast_range_150"
-		//"Ability14"		"special_bonus_unique_invoker_5" //"special_bonus_mp_400"
-		//"Ability15"		"special_bonus_cooldown_reduction_10"
-		//"Ability16"		"special_bonus_unique_invoker_2"	//"special_bonus_magic_resistance_35"
-		//"Ability17"		"special_bonus_unique_invoker_4"	//"special_bonus_intelligence_35"
+		// First row of talents will not work unless some invoker abilities present in hero kv (level up order ignored by client)...
+		"Ability17"		"special_bonus_unique_nether_wizard_1"
+		"Ability18"		"special_bonus_unique_nether_wizard_2"
+		"Ability19"		"special_bonus_unique_nether_wizard_3"
+		"Ability20"		"special_bonus_unique_nether_wizard_4"
+		"Ability21"		"special_bonus_unique_nether_wizard_5"
+		"Ability22"		"special_bonus_unique_nether_wizard_6"
+		"Ability23"		"special_bonus_unique_nether_wizard_7"
+		"Ability24"		"special_bonus_unique_nether_wizard_8"
 
 		"UnitLabel"         "hero"
 

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -4542,7 +4542,7 @@ function GetAbilityDamageModifierMultiplicative( event, caster, real_caster, tar
         end
         multiplicative_bonus = multiplicative_bonus * (1 + bonus)
     end
-    if GetLevelOfAbility(caster, "special_bonus_unique_invoker_1") >= 1 then
+    if GetLevelOfAbility(caster, "special_bonus_unique_nether_wizard_3") >= 1 then
         multiplicative_bonus = multiplicative_bonus * 1.05
     end
     if caster:HasModifier("modifier_mop2") then
@@ -14837,7 +14837,7 @@ function GetCooldownReductionFactor( caster, ability )
     if caster:HasModifier("modifier_item_night_shoulders") and ability == caster:GetAbilityByIndex(5) then
         factor = factor * 0.75
     end
-    if GetLevelOfAbility(caster, "special_bonus_unique_invoker_9") >= 1 then
+    if GetLevelOfAbility(caster, "special_bonus_unique_nether_wizard_4") >= 1 then
         factor = factor * 0.9
     end
     if caster.talents and caster.talents[110] and caster.talents[110] >= 1 then
@@ -20140,7 +20140,7 @@ function GetCastRangeBonus(hero)
     if hero:HasModifier("modifier_shadow_form_ds") and hero:HasModifier("modifier_class_ds2") then
         bonus = bonus + 450
     end
-    if GetLevelOfAbility(hero, "special_bonus_unique_invoker_5") >= 1 then
+    if GetLevelOfAbility(hero, "special_bonus_unique_nether_wizard_6") >= 1 then
         bonus = bonus + 300
     end
     return bonus
@@ -20736,7 +20736,7 @@ function PassiveStatCalculation(event)
     baseStats[STR] = baseStats[STR] + hero.runeword[5] + hero.runeword[16] + wingsOfDominanceStatsPerLevel * hero.talents[84] + hero.talents[63] * 15 + hero.talents[46] * 15 + hero.talents[10] * 15 + GetGlobalStrengthAuraStat() + GetAllStats(hero)
     baseStats[AGI] = baseStats[AGI] + hero.runeword[1] + hero.runeword[16] + wingsOfDominanceStatsPerLevel * hero.talents[84] + hero.talents[40] * 15 + hero.talents[46] * 15 + GetGlobalAgilityAuraStat() + GetAllStats(hero)
     baseStats[INT] = baseStats[INT] + hero.runeword[2] + wingsOfDominanceStatsPerLevel * hero.talents[84] + hero.talents[35] * 30 + GetGlobalIntellectAuraStat() + GetAllStats(hero)
-    if GetLevelOfAbility(hero, "special_bonus_unique_invoker_3") >= 1 then
+    if GetLevelOfAbility(hero, "special_bonus_unique_nether_wizard_8") >= 1 then
         baseStats[INT] = baseStats[INT] + 75
     end
     --primary static
@@ -20834,7 +20834,7 @@ function PassiveStatCalculation(event)
         manaPerInt = 0.0 --0.1
     end
     local maxManaBonusesFromNonItems = realBaseStats[INT] * manaPerInt + hero.talents[120] * 100
-    if GetLevelOfAbility(hero, "special_bonus_unique_invoker_4") >= 1 then
+    if GetLevelOfAbility(hero, "special_bonus_unique_nether_wizard_5") >= 1 then
         maxManaBonusesFromNonItems = maxManaBonusesFromNonItems + 500
     end
     baseStats[MANA] = hero:GetMaxMana() + maxManaBonusesFromNonItems --these base stats are wrong because mana per int is added by original values, needs fix to remove int mana
@@ -21398,7 +21398,7 @@ function PassiveStatCalculation(event)
                 if hero.talents[80] and hero.talents[80] > 0 then
                     static_bonus = static_bonus + 3 * hero.talents[80]
                 end
-                if GetLevelOfAbility(hero, "special_bonus_unique_invoker_10") >= 1 then
+                if GetLevelOfAbility(hero, "special_bonus_unique_nether_wizard_1") >= 1 then
                     static_bonus = static_bonus + 5
                 end
                 if hero.talents[139] and hero.talents[139] > 0 then
@@ -21529,7 +21529,7 @@ function PassiveStatCalculation(event)
                     end
                 end
                 local value5 = 0
-                if GetLevelOfAbility(hero, "special_bonus_unique_invoker_2") >= 1 then
+                if GetLevelOfAbility(hero, "special_bonus_unique_nether_wizard_7") >= 1 then
                     value5 = 35
                 end
                 local mresPerInt = 0.01
@@ -21920,7 +21920,7 @@ end
 
 function GetAllStats(hero)
     local value = 0
-    if GetLevelOfAbility(hero, "special_bonus_unique_invoker_6") >= 1 then
+    if GetLevelOfAbility(hero, "special_bonus_unique_nether_wizard_2") >= 1 then
         value = value + 15
     end
     return value


### PR DESCRIPTION
I added custom talents because valve constantly mess with hero unique talents by removing or renaming them

Invoker pick screen
From:
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/7c049e97-6c23-4aa5-9681-e1851741e53c)
To:
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/46dd79c4-ba49-47a6-86c4-125d50ef536c)

Invoker talents
From:
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/ed1065be-7deb-4426-83bc-0157c43db89c)
To:
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/f945577d-6ebe-4878-8c34-2cbd74328d83)