### PR TITLE
Better auto sell filters

### DIFF
--- a/content/panorama/layout/custom_game/eloranking.xml
+++ b/content/panorama/layout/custom_game/eloranking.xml
@@ -3503,8 +3503,14 @@
 
 		</Panel>
 		<Panel class="WeaponList" hittest="false" id="WeaponListStart">
-			<Button id="QuestlogButton2" class="Butt" onactivate="SetAutoSell()">	
-				<Label class="ButtText" id="autoselltext" text="Auto Sell: None" />			
+			<Button id="QuestlogButton3" class="Butt" onactivate="SetAutoSellItems()">	
+				<Label class="ButtText" id="autoselltext1" text="Don't Auto Sell Items" />			
+			</Button>
+			<Button id="QuestlogButton4" class="Butt" onactivate="SetAutoSellArtifacts()">	
+				<Label class="ButtText" id="autoselltext2" text="Don't Auto Sell Artifacts" />			
+			</Button>
+			<Button id="QuestlogButton5" class="Butt" onactivate="SetAutoSellSouls()">	
+				<Label class="ButtText" id="autoselltext3" text="Don't Auto Sell Souls" />			
 			</Button>
 		</Panel>
 		<Panel class="MonsterSpellcastList" hittest="false" id="monsterspells">

--- a/content/panorama/scripts/custom_game/eloranking.js
+++ b/content/panorama/scripts/custom_game/eloranking.js
@@ -19,6 +19,8 @@ var shopItemsAdded = false;
 var recipesItemsAdded = false;
 var save_cooldown = 0;
 var autosell = 0;
+var autosellArti = 0;
+var autosellSouls = 0;
 var main_stats_detailed = false;
 
 var hpPerStr = 10; //20;
@@ -3136,23 +3138,91 @@ function SetMyChest(args)
     }
 }
 
-function SetAutoSell(args){
+function SetAutoSellItems() {
     autosell = autosell + 1;
-    if(autosell > 6){
+
+    if(autosell > 15){
         autosell = 0;
-        $("#autoselltext").text = "Auto Sell: Off";
+        $("#autoselltext1").text = "Don't Auto Sell Items";
     }
     if(autosell == 1){
+        autosell = 2;
+        $("#autoselltext1").text = "Auto Sell: Common Items and below";
+    }
+    if(autosell == 3){
         autosell = 4;
-        $("#autoselltext").text = "Auto Sell: Epic and below";
+        $("#autoselltext1").text = "Auto Sell: Uncommon Items and below";
     }
     if(autosell == 5){
-        $("#autoselltext").text = "Auto Sell: Legendary and below";
+        autosell = 6;
+        $("#autoselltext1").text = "Auto Sell: Rare Items and below";
     }
-    if(autosell == 6){
-        $("#autoselltext").text = "Auto Sell: Immortal and below";
+    if(autosell == 7){
+        autosell = 8;
+        $("#autoselltext1").text = "Auto Sell: Epic Items and below";
+    }
+    if(autosell == 9){
+        autosell = 10;
+        $("#autoselltext1").text = "Auto Sell: Legendary Items and below";
+    }
+    if(autosell == 11){
+        autosell = 12;
+        $("#autoselltext1").text = "Auto Sell: Immortal Items and below";
+    }
+    if(autosell == 13){
+        autosell = 14;
+        $("#autoselltext1").text = "Auto Sell: Divine Items and below";
+    }
+    if(autosell == 15){
+        autosell = 16;
+        $("#autoselltext1").text = "Auto Sell: Mythical Items and below";
     }
     GameEvents.SendCustomGameEventToServer( "setautosell", { "player_id": Players.GetLocalPlayer(), "index": autosell } );
+}
+
+function SetAutoSellArtifacts() {
+    autosellArti = autosellArti + 1;
+
+    if(autosellArti > 10){
+        autosellArti = 0;
+        $("#autoselltext2").text = "Don't Auto Sell Artifacts";
+    }
+    if(autosellArti == 1){
+        autosellArti = 2;
+        $("#autoselltext2").text = "Auto Sell: Epic Artifacts and below";
+    }
+    if(autosellArti == 3){
+        autosellArti = 4;
+        $("#autoselltext2").text = "Auto Sell: Legendary Artifacts and below";
+    }
+    if(autosellArti == 5){
+        autosellArti = 6;
+        $("#autoselltext2").text = "Auto Sell: Immortal Artifacts and below";
+    }
+    if(autosellArti == 7){
+        autosellArti = 8;
+        $("#autoselltext2").text = "Auto Sell: Divine Artifacts and below";
+    }
+    if(autosellArti == 9){
+        autosellArti = 10;
+        $("#autoselltext2").text = "Auto Sell: Mythical Artifacts and below";
+    }
+    GameEvents.SendCustomGameEventToServer( "setautosell", { "player_id": Players.GetLocalPlayer(), "indexArti" : autosellArti } );
+}
+
+function SetAutoSellSouls() {
+    autosellSouls = autosellSouls + 1;
+
+    if(autosellSouls > 1){
+        autosellSouls = 0;
+        $("#autoselltext3").text = "Don't Auto Sell Souls";
+    }
+    if(autosellSouls == 1){
+        autosellSouls = 2;
+        $("#autoselltext3").text = "Auto Sell: All Souls";
+    }
+
+    GameEvents.SendCustomGameEventToServer( "setautosell", { "player_id": Players.GetLocalPlayer(), "indexSouls" : autosellSouls } );
 }
 
 function TalentPressed(args){

--- a/game/scripts/vscripts/addon_game_mode.lua
+++ b/game/scripts/vscripts/addon_game_mode.lua
@@ -13752,11 +13752,22 @@ function RefreshTalents(event, args)
       function SetAutoSell(event, args)
         local id = args['player_id']
         local index = args['index']
+        local indexArti = args['indexArti']
+        local indexSouls = args['indexSouls']
         local player = PlayerResource:GetPlayer(id)
+
         if player then
           local hero = player:GetAssignedHero()
           if hero then
-            hero.autosell = index
+            if(index ~= nil) then
+              hero.autosell = index
+            end
+            if(indexArti ~= nil) then
+              hero.autosellArti = indexArti
+            end
+            if(indexSouls ~= nil) then
+              hero.autosellSouls = indexSouls
+            end
           end
         end
       end

--- a/game/scripts/vscripts/debug_tools.lua
+++ b/game/scripts/vscripts/debug_tools.lua
@@ -22,9 +22,30 @@ function Init()
         GameRules:Playtesting_UpdateAddOnKeyValues()
     end, "reload_kv", FCVAR_CHEAT)
     --]]
+
+    Convars:RegisterCommand("droptempleitem", function(_, lootQuality, lootModifier)
+        local lootQuality = tonumber(lootQuality)
+        local isSoul = lootModifier == "soul" -- probably impossible without modifying DropTempleItem so unimplemented for now
+        local isArti = lootModifier == "arti"
+
+        DebugDropTempleItem(lootQuality, isSoul, isArti)
+    end, "droptempleitem", FCVAR_CHEAT)
+
     local villageDummyPoint = Vector(-14972.935547, 14804.335938, 128.000000)
     
     CreateUnitByName("npc_dota_creature_tutorial_dummy", villageDummyPoint, false, nil, nil, DOTA_TEAM_NEUTRALS)
 
     _G._debugToolsInit = true
+
+end
+
+function DebugDropTempleItem(lootQuality, isSoul, isArti)
+    if not IsInToolsMode() then -- just to be 100% safe
+        return
+    end
+    if(lootQuality == nil) then
+        return
+    end
+
+    COverthrowGameMode:DropTempleItem(PlayerResource:GetSelectedHeroEntity(0), 100, 2, lootQuality, isArti)
 end

--- a/game/scripts/vscripts/items.lua
+++ b/game/scripts/vscripts/items.lua
@@ -7294,7 +7294,76 @@ function COverthrowGameMode:DropTempleItem( unit, reward, drop_type, buy_quality
 						end
 
 						--autosell feature
-						if hero and hero.autosell and lootquality and lootquality <= hero.autosell then
+						local isAutoSell = false
+						
+						if(artifact) then
+							-- Auto Sell: Epic Artifacts and below
+							if(hero.autosellArti == 2) then
+								isAutoSell = lootquality <= 4
+							end
+							-- Auto Sell: Legendary Artifacts and below
+							if(hero.autosellArti == 4) then
+								isAutoSell = lootquality <= 5
+							end
+							-- Auto Sell: Immortal Artifacts and below
+							if(hero.autosellArti == 6) then
+								isAutoSell = lootquality <= 6
+							end
+							-- Auto Sell: Divine Artifacts and below
+							if(hero.autosellArti == 8) then
+								isAutoSell = lootquality <= 7
+							end
+							-- Auto Sell: Mythical Artifacts and below
+							if(hero.autosellArti == 10) then
+								isAutoSell = lootquality <= 8
+							end
+						else
+							if(itemdrop) then
+								local isSoulDrop = string.sub(spawnedItem, 1, string.len("item_mastery_")) == "item_mastery_"
+
+								-- Auto Sell: All Souls
+								local isSoulProtected = true
+								if(isSoulDrop and hero.autosellSouls == 0) then
+									isSoulProtected = false
+								end
+
+								print("isSoulProtected ", isSoulProtected)
+								-- Auto Sell: Common Items and below
+								if(hero.autosell == 2) then
+									isAutoSell = lootquality <= 1 and isSoulProtected
+								end
+								-- Auto Sell: Uncommon Items and below
+								if(hero.autosell == 4) then
+									isAutoSell = lootquality <= 2 and isSoulProtected
+								end
+								-- Auto Sell: Rare Items and below
+								if(hero.autosell == 6) then
+									isAutoSell = lootquality <= 3 and isSoulProtected
+								end
+								-- Auto Sell: Epic Items and below
+								if(hero.autosell == 8) then
+									isAutoSell = lootquality <= 4 and isSoulProtected
+								end
+								-- Auto Sell: Legendary Items and below
+								if(hero.autosell == 10) then
+									isAutoSell = lootquality <= 5 and isSoulProtected
+								end
+								-- Auto Sell: Immortal Items and below
+								if(hero.autosell == 12) then
+									isAutoSell = lootquality <= 6 and isSoulProtected
+								end
+								-- Auto Sell: Divine Items and below
+								if(hero.autosell == 14) then
+									isAutoSell = lootquality <= 7 and isSoulProtected
+								end
+								-- Auto Sell: Mythical Items and below
+								if(hero.autosell == 16) then
+									isAutoSell = lootquality <= 8 and isSoulProtected
+								end
+							end
+						end
+
+						if hero and isAutoSell then
 							itemdrop = false
 							local gold = GetSellValueByItemLevel(lootquality)
 			                EmitSoundOn("DOTA_Item.Hand_Of_Midas", hero)


### PR DESCRIPTION
First row let you select auto sell for items based on quality
Second row let you select auto sell for artifacts based on quality
Third row let you select that you wish to protect souls from auto sell or no
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/d8f05b37-0e9b-4d7d-acd5-9c91f4c01bc5)

I also added debug drop item command [here](https://github.com/Catzee/Titanbreaker/pull/25/commits/99b68bbed03307823b81714ed6d29d867b5c5939)