### PR TITLE
Fixed spiritwolf talisman effect duration

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -9976,8 +9976,8 @@
 		"DOTA_Tooltip_modifier_dot_gen"                                                       "Damage over Time"
 		"DOTA_Tooltip_modifier_dot_gen_Description"                                           " "
 
-		"DOTA_Tooltip_modifier_ursa_prot"                                                       "Protection of Ursa"
-		"DOTA_Tooltip_modifier_ursa_prot_Description"                                           " "
+		"DOTA_Tooltip_modifier_swipe_of_ursa_proc"                                                       "Protection of Ursa"
+		"DOTA_Tooltip_modifier_swipe_of_ursa_proc_Description"                                           " "
 
 		"DOTA_Tooltip_modifier_tunic_hunt_item2"                                                       "Tunic of the Hunt"
 		"DOTA_Tooltip_modifier_tunic_hunt_item2_Description"                                           "Armor reduced."

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -75602,32 +75602,7 @@
 	                 "MODIFIER_PROPERTY_STATS_AGILITY_BONUS" "1"
 	            }
 	        }
-	        "modifier_ursa_prot"
-	        {
-	        	"Duration" 	"6"
-	            "Passive"  "0"
-	            "IsHidden" "0" 
-	            "IsPurgable"		"1"
-	            "IsBuff"			"1"
-	            "IsDebuff"			"0"
-	            "IsStunDebuff"		"0"
-	            "TextureName" "ursa_enrage"
-	            "OnCreated"
-	            {
-	            	"AttachEffect"
-	            	{
-	            		"EffectName"        "particles/econ/items/pangolier/pangolier_ti8_immortal/pangolier_ti8_immortal_shield_buff_parent.vpcf"
-	            		"EffectAttachType"  "attach_hitloc"
-	            		"Target"            "TARGET"
-	            		"ControlPointEntities"
-	            		{
-	            			"TARGET"	"attach_hitloc"
-	            			"TARGET"	"attach_hitloc"
-	            		}
-	            	}
-	            }
-	        }
-	        
+
 	    	"modifier_runeofdetection"
 	        {
 	            "Passive"          "0"

--- a/game/scripts/vscripts/addon_init.lua
+++ b/game/scripts/vscripts/addon_init.lua
@@ -13,3 +13,5 @@ LinkLuaModifier("modifier_phased_lua", "modifiers/modifier_phased_lua", LUA_MODI
 --LinkLuaModifier("modifier_path_health_buff", "modifiers/modifier_path_health_buff", LUA_MODIFIER_MOTION_NONE)
 -- fix for death with pl 6th ability buff due to heal after damage
 LinkLuaModifier("modifier_godschosen_2", "modifiers/heroes/sanctified_crusader/modifier_godschosen_2", LUA_MODIFIER_MOTION_NONE)
+-- swipe of ursa proc duration fix
+LinkLuaModifier("modifier_swipe_of_ursa_proc", "modifiers/path_talents/modifier_swipe_of_ursa_proc", LUA_MODIFIER_MOTION_NONE)

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -24562,7 +24562,9 @@ function SwipeOfUrsaTalent(caster, original_ability)
         ApplyBuffAOE(buffevent)
         DamageAOE(event)
         if caster:HasModifier("modifier_pathbuff_042") and caster.combat_system_ability then
-            caster.combat_system_ability:ApplyDataDrivenModifier(caster, caster, "modifier_ursa_prot", {Duration = 10})
+            --local mod = caster.combat_system_ability:ApplyDataDrivenModifier(caster, caster, "modifier_ursa_prot", {Duration = 10})
+            -- I have no idea why data driven modifier duration = 10 ignored and somewhere set to 6... Probably dota modifier internal name used or some weird data driven things
+            caster:AddNewModifier(caster, nil, "modifier_swipe_of_ursa_proc", { Duration = 10})
         end
     end)
 end

--- a/game/scripts/vscripts/modifiers/path_talents/modifier_swipe_of_ursa_proc.lua
+++ b/game/scripts/vscripts/modifiers/path_talents/modifier_swipe_of_ursa_proc.lua
@@ -1,0 +1,36 @@
+modifier_swipe_of_ursa_proc = class({
+    IsHidden = function()
+        return false
+    end,
+    IsPurgable = function()
+        return false
+    end,
+	IsDebuff = function()
+		return false
+	end,
+    GetTexture = function()
+        return "ursa_enrage"
+    end
+})
+
+function modifier_swipe_of_ursa_proc:OnCreated()
+    if(not IsServer()) then
+        return
+    end
+
+    self.parent = self:GetParent()
+
+    local parentOrigin = self.parent:GetAbsOrigin()
+
+    local particle = ParticleManager:CreateParticle(
+        "particles/econ/items/pangolier/pangolier_ti8_immortal/pangolier_ti8_immortal_shield_buff_parent.vpcf", 
+        PATTACH_ABSORIGIN_FOLLOW, 
+        self.parent)
+    ParticleManager:SetParticleControlEnt(particle, 0, self.parent, PATTACH_ABSORIGIN_FOLLOW, "attach_hitloc", parentOrigin, true)
+    ParticleManager:SetParticleControlEnt(particle, 1, self.parent, PATTACH_ABSORIGIN_FOLLOW, "attach_hitloc", parentOrigin, true)
+    ParticleManager:SetParticleControl(particle, 3, Vector(50, 0, 0))
+    ParticleManager:SetParticleControl(particle, 5, Vector(0, 0, 0))
+    ParticleManager:SetParticleControl(particle, 8, Vector(50, 0, 0))
+    
+    self:AddParticle(particle, false, false, 1, false, false)
+end


### PR DESCRIPTION
I have no idea why data driven modifier duration = 10 ignored and somewhere set to 6... Probably dota modifier internal name used or some weird data driven things. I also fixed this modifier particle on top of that (some control points was missing)