### PR TITLE
Adjusted missing crits

### DIFF
--- a/game/panorama/localization/addon_english.txt
+++ b/game/panorama/localization/addon_english.txt
@@ -156,7 +156,7 @@
 		"talent60"								"Wolf Rider: For every 20 Points of Movement Speed beyond 300 gain 1% / 2% / 3% increased Damage and Damage Reduction, both capped at 50%."
 
 		"talent61"								"Demon Fury: Gain Agility equal to 5% / 10% / 15% of your Strength and Intellect."
-		"talent62"								"Dark Wizardry: Gain Spellpower equal to 3% / 6% / 9% of your Strength, Agility and Intellect and Ability Damage instances with a scaling of 600% or higher gain a 1% / 2% / 3% chance to Critical Strike for 300%."
+		"talent62"								"Dark Wizardry: Gain Spellpower equal to 3% / 6% / 9% of your Strength, Agility and Intellect and Ability Damage instances with a scaling of 600% or higher gain a 4% / 8% / 12% chance to Critical Strike for 275%."
 		"talent63"								"Warden of Souls: + 15 / 30 / 45 Strength and whenever you die, there is a 7% / 14% / 21% chance to not lose a life (capped at 50%)."
 		"talent64"								"A Light in the Dark: Increase all Holy and Shadow Damage by 10% / 20% / 30% and all Ability Damage caused by your 4th Ability by 10% / 20% / 30%."
 		"talent65"								"Shadow Colossus: + 5% / 10% / 15% Primary Attribute and 250 / 500 / 750 Health, at the cost of 15% reduced Movement Speed while in combat."

--- a/game/panorama/localization/addon_english.txt
+++ b/game/panorama/localization/addon_english.txt
@@ -109,7 +109,7 @@
 		"talent16"								"Moonlight Fairies: Increase all Arcane and Nature Damage by 15% / 30% / 45% and all Healing caused by 5% / 10% / 15%. After you Heal yourself, your Primary Attribute is increased by 5% / 10% / 15% for 15 secs."
 		"talent17"								"Full Moon: + 10% / 15% / 20% Cooldown Reduction for your 3rd Ability and + 10% / 15% / 20% Ability Critical Strike Damage and Healing."
 		"talent18"								"Tigerbites: + 10% / 20% / 30% Attack Damage and + 50 / 100 / 150 Auto Attack Damage"
-		"talent19"								"Phantom Assassin: + 1% / 2% / 3% chance to Critical Strike for 200% with Abilities and whenever your 3rd Ability lands a Critical Strike, there is a 10% / 20% / 30% chance to reset its cooldown, with an inner cooldown of 30 secs."
+		"talent19"								"Phantom Assassin: + 5% / 10% / 15% chance to Critical Strike for 360% with Abilities and whenever your 3rd Ability lands a Critical Strike, there is a 10% / 20% / 30% chance to reset its cooldown, with an inner cooldown of 30 secs."
 		"talent20"								"Careful Aim: For every second you stand still your Damage and Healing is increased by 5% / 10% / 15%, stacking up to 5 times."
 		"talent21"								"Fragile Moon: Increase all Damage by 15% / 30% / 45% and cause your next Auto Attack Critical Strike Damage to be increased by 15% / 30% / 45% every 5 secs, at the cost of reducing Armor and Spell Resistance by 5 / 10 / 15."
 		"talent22"								"The Stars Aligned: Every 15 secs, the next time you deal Damage with an Ability, it will be a guaranteed Critical Strike for 200% / 250% / 300%. Does not proc on Ability Damage with a scaling below 600%." //\nWhenever you kill a creature, the cooldown is reset.

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -7140,7 +7140,8 @@
 
 		"DOTA_Tooltip_ability_item_ancient_wolf"                                       "<font color=\"#00ffff\">[Ancient] Armor of the Red Wolf"
 		"DOTA_Tooltip_ability_item_ancient_wolf_Description"                           "Increases the level of Sharp Claws by 2.\nIncreases the level of Wolf Rage by 2.\n<font color=\"#FF6600\">Uniquely Equipped.</font>\n"
-		"DOTA_Tooltip_ability_item_ancient_wolf_bonus_stat1"                           "%Ability Critical Strike Chance (150%): +"
+		"DOTA_Tooltip_Ability_item_ancient_wolf_bonus_stat1"                           "%Ability Critical Strike Chance: "
+		"DOTA_Tooltip_Ability_item_ancient_wolf_bonus_stat2"                           "%Ability Critical Strike Factor: "
 
 		"DOTA_Tooltip_ability_item_ancient_dragon"                                       "<font color=\"#00ffff\">[Ancient] Dragonscale Shoulders"
 		"DOTA_Tooltip_ability_item_ancient_dragon_Description"                           "Increases the Level of Mana Shield by 2 if it is atleast Level 1.\n<font color=\"#FF6600\">Uniquely Equipped.</font>"

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -8122,7 +8122,7 @@
 		"DOTA_Tooltip_ability_item_pathbuff_068_Description"  "<font color=\"#FF6600\">+3 for the Path Talent Apocalypse.</font>\nAsteroid Extinction: While under Apocalypse, Rain of Stars Damage is increased by 100%%.\nTomb Raider: Lord of Bones proc chance is increased by 3%%, if it is at least Level 1."
 		"DOTA_Tooltip_ability_item_pathbuff_068_stat1"  "Primary Attribute: "
 		"DOTA_Tooltip_ability_item_pathbuff_069"  "<font color=\"#ffd700\">[Divine] Tamed Moose"
-		"DOTA_Tooltip_ability_item_pathbuff_069_Description"  "<font color=\"#FF6600\">+3 for the Path Talent Cruel Taskmaster.</font>\nAura of the Moose: Your Summons and Companions gain a 15%% chance to Critical Strike for 200%%."
+		"DOTA_Tooltip_ability_item_pathbuff_069_Description"  "<font color=\"#FF6600\">+3 for the Path Talent Cruel Taskmaster.</font>\nAura of the Moose: Your Summons and Companions gain a 10%% chance to Critical Strike for 325%%."
 		"DOTA_Tooltip_ability_item_pathbuff_070"  "<font color=\"#ffd700\">[Divine] Cutthroat"
 		"DOTA_Tooltip_ability_item_pathbuff_070_Description"  "<font color=\"#FF6600\">+3 for the Path Talent From the Shadows.</font>\nAmbush Master: While under the effect of Patient Prowler and From the Shadows, your Primary Attribute is increased by 25%%.\nAll Ability Damage is increased by 25%% against targets above 75%% of max Health."
 		"DOTA_Tooltip_ability_item_pathbuff_071"  "<font color=\"#ffd700\">[Divine] Valyrian Steel Hook"

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -7399,8 +7399,10 @@
 		"DOTA_Tooltip_ability_item_crit_pure_immortal_2"                                             "<font color=\"#00ffff\">[Ancient] Ballista of Execution"
 		"DOTA_Tooltip_ability_item_crit_pure_immortal_2_Description"                                 "Increases the level of Blood Wolf by 2.\n<font color=\"#FF6600\">Uniquely Equipped.</font>\n"
 		"DOTA_Tooltip_ability_item_crit_pure_immortal_2_bonus_stat0"                                 "Attack Speed: "
-		"DOTA_Tooltip_ability_item_crit_pure_immortal_2_bonus_stat1"                                 "%Ability Critical Strike chance for 200%:"
-		"DOTA_Tooltip_ability_item_crit_pure_immortal_2_bonus_stat2"                                 "%Auto Attack Critical Strike chance for 200%:"
+		"DOTA_Tooltip_ability_item_crit_pure_immortal_2_bonus_stat1"                                 "%Ability Critical Strike Chance: "
+		"DOTA_Tooltip_ability_item_crit_pure_immortal_2_bonus_stat2"                                 "%Ability Critical Strike Factor: "
+		"DOTA_Tooltip_ability_item_crit_pure_immortal_2_bonus_stat3"                                 "%Auto Attack Critical Strike Chance: "
+		"DOTA_Tooltip_ability_item_crit_pure_immortal_2_bonus_stat4"                                 "%Auto Attack Critical Strike Factor: "
 
 		"DOTA_Tooltip_Ability_item_bootscrit3"  											"<font color=\"#00ffff\">[Ancient] Alphamane Mount"
 		"DOTA_Tooltip_Ability_item_bootscrit3_Description"  								"<h1>Alpharun</h1>Gain a 50%% Movement Speed Burst, Phased Effect and 90%% Evasion for 3 secs.\n\nPassive: All damage dealing Ability Critical Strikes caused by you deal 25%% increased Damage.\nDoes not stack with Firebat.\n<font color=\"#00ff00\">Mount: Gain 25%% increased Movement Speed while out of combat."

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -30157,22 +30157,22 @@
 	        "01"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat1"    "30" // passive crit chance
+	            "bonus_stat1"    "20" // passive crit chance
 	        }
 	        "02"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat2"    "300" // passive crit multiplier
+	            "bonus_stat2"    "325" // passive crit multiplier
 	        }
 	        "03"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat3"    "35" // active crit chance
+	            "bonus_stat3"    "25" // active crit chance
 	        }
 	        "04"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat4"    "360" // active crit multiplier
+	            "bonus_stat4"    "460" // active crit multiplier
 	        }
 	        "05"
 	        {
@@ -30480,22 +30480,22 @@
 	        "06"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat8"    "30" // passive crit chance
+	            "bonus_stat8"    "20" // passive crit chance
 	        }
 	        "07"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat9"    "300" // passive crit multiplier
+	            "bonus_stat9"    "325" // passive crit multiplier
 	        }
 	        "06"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat10"    "35" // active crit chance
+	            "bonus_stat10"    "25" // active crit chance
 	        }
 	        "07"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat11"    "360" // active crit multiplier
+	            "bonus_stat11"    "460" // active crit multiplier
 	        }
 	        "08"
 	        {

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -22669,7 +22669,7 @@
 	        "02"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat3"    "325" // passive crit chance
+	            "bonus_stat3"    "325" // passive crit multiplier
 	        }
 	        "03"
 	        {
@@ -24652,7 +24652,12 @@
 	        "01"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat1"    "10"
+	            "bonus_stat1"    "15" // passive crit chance
+	        }
+	        "02"
+	        {
+	            "var_type"      "FIELD_INTEGER"
+	            "bonus_stat2"    "180" // passive crit multiplier
 	        }
 	    }
 

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -22757,17 +22757,27 @@
 	    	"01"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat0"    "100"
+	            "bonus_stat0"    "100" // attack speed
 	        }
 	        "01"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat1"    "5"
+	            "bonus_stat1"    "15" // passive ability crit chance
 	        }
-	        "01"
+	        "02"
 	        {
 	            "var_type"      "FIELD_INTEGER"
-	            "bonus_stat2"    "5"
+	            "bonus_stat2"    "180" // passive ability crit multiplier
+	        }
+	        "03"
+	        {
+	            "var_type"      "FIELD_INTEGER"
+	            "bonus_stat3"    "15" // passive aa crit chance
+	        }
+	        "04"
+	        {
+	            "var_type"      "FIELD_INTEGER"
+	            "bonus_stat4"    "180" // passive aa crit multiplier
 	        }
 	    }
 

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -1705,7 +1705,7 @@ function DamageUnit( event )
     if critpossible == true and caster:HasModifier("modifier_mythic_abilcrit") then
         critchance = critchancefactor * caster:GetModifierStackCount("modifier_mythic_abilcrit", nil) + flatCritChance
         if math.random(1,100) <= critchance then
-            finaldamage = finaldamage*2*critdmgbonusfactor
+            finaldamage = finaldamage*3*critdmgbonusfactor
             critpossible = false
         end
     end
@@ -6977,7 +6977,7 @@ function HealUnit( event )
     if critpossible == true and event.caster:HasModifier("modifier_mythic_abilcrit") then
         critchance = critchancefactor * caster:GetModifierStackCount("modifier_mythic_abilcrit", nil)
         if math.random(1,100) <= critchance then
-            event.heal = event.heal*5*critdmgbonusfactor
+            event.heal = event.heal*3*critdmgbonusfactor
             displaynumber = 1
             critpossible = false
         end

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -2024,9 +2024,9 @@ function DamageUnit( event )
         end
     end
     if critpossible == true and caster.talents and caster.talents[19] and caster.talents[19] > 0 then
-        critchance = caster.talents[19] * critchancefactor + flatCritChance
+        critchance = caster.talents[19] * 5 * critchancefactor + flatCritChance
         if math.random(1,100) <= critchance then
-            finaldamage = finaldamage*2*critdmgbonusfactor
+            finaldamage = finaldamage*3.6*critdmgbonusfactor
             critpossible = false
         end
     end

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -1571,10 +1571,11 @@ function DamageUnit( event )
         critdmgbonusfactor = critdmgbonusfactor + 0.25 * caster.talents[79]
     end
     local flatCritChance = GetFlatCritChance(caster) * critchancefactor
+    caster.talents[62] = 100
     if critpossible == true and is_very_big_hit and caster.talents and caster.talents[62] and caster.talents[62] > 0 then
-        critchance = critchancefactor * caster.talents[62] + flatCritChance
+        critchance = critchancefactor * 4 * caster.talents[62] + flatCritChance
         if math.random(1,100) <= critchance then
-            finaldamage = finaldamage*3*critdmgbonusfactor
+            finaldamage = finaldamage*2.75*critdmgbonusfactor
             critpossible = false
         end
     end

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -1742,9 +1742,9 @@ function DamageUnit( event )
         end
     end
     if critpossible == true and caster:HasModifier("modifier_pathbuff_069") and (event.fromcompanion or event.fromsummon or event.ComesFromPet) then
-        critchance = 15 * critchancefactor + flatCritChance
+        critchance = 10 * critchancefactor + flatCritChance
         if math.random(1,100) <= critchance then
-            finaldamage = finaldamage*2*critdmgbonusfactor
+            finaldamage = finaldamage*3.25*critdmgbonusfactor
             critpossible = false
         end
     end

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -1764,11 +1764,16 @@ function DamageUnit( event )
             end
         end
     end
-    if critpossible == true and caster:HasModifier("modifier_item_ancient_wolf") then
-        critchance = 10*critchancefactor + flatCritChance
-        if math.random(1,100) <= critchance then
-            finaldamage = finaldamage*1.5*critdmgbonusfactor
-            critpossible = false
+    local armorOfRedWolfModifier = caster:FindModifierByName("modifier_item_ancient_wolf")
+    if critpossible == true and armorOfRedWolfModifier then
+        local armorOfRedWolfModifierAbility = armorOfRedWolfModifier:GetAbility()
+        if(armorOfRedWolfModifierAbility) then
+            critchance = armorOfRedWolfModifierAbility:GetSpecialValueFor("bonus_stat1")*critchancefactor + flatCritChance
+            local critDmgFactor = armorOfRedWolfModifierAbility:GetSpecialValueFor("bonus_stat2") / 100
+            if math.random(1,100) <= critchance then
+                finaldamage = finaldamage*critDmgFactor*critdmgbonusfactor
+                critpossible = false
+            end
         end
     end
     if critpossible == true and caster.talents and caster.talents[158] > 0 then
@@ -7015,12 +7020,17 @@ function HealUnit( event )
             critpossible = false
         end
     end
-    if critpossible == true and event.caster:HasModifier("modifier_item_ancient_wolf") then
-        critchance = 10*critchancefactor
-        if math.random(1,100) <= critchance then
-            event.heal = event.heal*2.25*critdmgbonusfactor
-            displaynumber = 1
-            critpossible = false
+    local armorOfRedWolfModifier = caster:FindModifierByName("modifier_item_ancient_wolf")
+    if critpossible == true and armorOfRedWolfModifier then
+        local armorOfRedWolfModifierAbility = armorOfRedWolfModifier:GetAbility()
+        if(armorOfRedWolfModifierAbility) then
+            critchance = armorOfRedWolfModifierAbility:GetSpecialValueFor("bonus_stat1")*critchancefactor
+            local critDmgFactor = armorOfRedWolfModifierAbility:GetSpecialValueFor("bonus_stat2") / 100
+            if math.random(1,100) <= critchance then
+                event.heal = event.heal*critDmgFactor*critdmgbonusfactor
+                displaynumber = 1
+                critpossible = false
+            end
         end
     end
     if critpossible == true and event.caster:HasModifier("modifier_item_crit_pure_immortal_2") then

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -1799,11 +1799,16 @@ function DamageUnit( event )
             critpossible = false
         end
     end
-    if critpossible == true and caster:HasModifier("modifier_item_crit_pure_immortal_2") then
-        critchance = 5*critchancefactor + flatCritChance
-        if math.random(1,100) <= critchance then
-            finaldamage = finaldamage*2*critdmgbonusfactor
-            critpossible = false
+    local ballistaOfExectionModifier = caster:FindModifierByName("modifier_item_crit_pure_immortal_2")
+    if critpossible == true and ballistaOfExectionModifier then
+        local ballistaOfExectionModifierAbility = ballistaOfExectionModifier:GetAbility()
+        if(ballistaOfExectionModifierAbility) then
+            critchance = ballistaOfExectionModifierAbility:GetSpecialValueFor("bonus_stat1")*critchancefactor + flatCritChance
+            local critDmgFactor = ballistaOfExectionModifierAbility:GetSpecialValueFor("bonus_stat2") / 100
+            if math.random(1,100) <= critchance then
+                finaldamage = finaldamage*critDmgFactor*critdmgbonusfactor
+                critpossible = false
+            end
         end
     end
     local templeArmorModifier = caster:FindModifierByName("modifier_item_crit_pure_immortal3")
@@ -7033,12 +7038,17 @@ function HealUnit( event )
             end
         end
     end
-    if critpossible == true and event.caster:HasModifier("modifier_item_crit_pure_immortal_2") then
-        critchance = 5*critchancefactor
-        if math.random(1,100) <= critchance then
-            event.heal = event.heal*5*critdmgbonusfactor
-            displaynumber = 1
-            critpossible = false
+    local ballistaOfExectionModifier = event.caster:FindModifierByName("modifier_item_crit_pure_immortal_2")
+    if critpossible == true and ballistaOfExectionModifier then
+        local ballistaOfExectionModifierAbility = ballistaOfExectionModifier:GetAbility()
+        if(ballistaOfExectionModifierAbility) then
+            critchance = ballistaOfExectionModifierAbility:GetSpecialValueFor("bonus_stat1")*critchancefactor
+            local critDmgFactor = ballistaOfExectionModifierAbility:GetSpecialValueFor("bonus_stat2") / 100
+            if math.random(1,100) <= critchance then
+                event.heal = event.heal*critDmgFactor*critdmgbonusfactor
+                displaynumber = 1
+                critpossible = false
+            end
         end
     end
     local armageddon = event.caster:FindModifierByName("modifier_item_crit_pure_immortal")
@@ -25029,8 +25039,12 @@ function CheckForAutoAttackCriticalStrikeProcs(caster, target)
     if caster:HasModifier("modifier_item_crit_pure_immortal_3") then
         AutoAttackCriticalStrike({attacker = caster, target = target, ability = caster.combat_system_ability, aacrit_factor = 750, aacrit_chance = 15})
     end
-    if caster:HasModifier("modifier_item_crit_pure_immortal_2") then
-        AutoAttackCriticalStrike({attacker = caster, target = target, ability = caster.combat_system_ability, aacrit_factor = 500, aacrit_chance = 5})
+    local ballistaOfExection = caster:FindModifierByName("modifier_item_crit_pure_immortal_2")
+    if ballistaOfExection then
+        local ballistaOfExectionAbility = ballistaOfExection:GetAbility()
+        if(ballistaOfExectionAbility) then
+            AutoAttackCriticalStrike({attacker = caster, target = target, ability = caster.combat_system_ability, aacrit_factor = ballistaOfExectionAbility:GetSpecialValueFor("bonus_stat4"), aacrit_chance = ballistaOfExectionAbility:GetSpecialValueFor("bonus_stat3")})
+        end
     end
     if caster:HasModifier("modifier_item_set_agi_set_crit_t1") then
         AutoAttackCriticalStrike({attacker = caster, target = target, ability = caster.combat_system_ability, aacrit_factor = 275, aacrit_chance = 5})

--- a/game/scripts/vscripts/items.lua
+++ b/game/scripts/vscripts/items.lua
@@ -298,7 +298,7 @@ function COverthrowGameMode:UpdateMythicWeaponStats(hero)
 				if stat == "% Attack Speed" then
 					buff = "modifier_mythic_as"
 				end
-				if stat == "% Ability Crit (200%)" then
+				if stat == "% Ability Crit (300%)" then
 					buff = "modifier_mythic_abilcrit"
 				end
 				if stat == " Armor" then
@@ -508,10 +508,10 @@ function COverthrowGameMode:MythicWeaponAttributeValue( attribute )
 	if attribute == " Auto Attack Damage" then
 		return 5
 	end
-	if attribute == "% Ability Crit (200%)" and COverthrowGameMode.version == 1 then
+	if attribute == "% Ability Crit (300%)" and COverthrowGameMode.version == 1 then
 		return 0.33333
 	end
-	if attribute == "% Ability Crit (200%)" and COverthrowGameMode.version == 2 then
+	if attribute == "% Ability Crit (300%)" and COverthrowGameMode.version == 2 then
 		return 0.11
 	end
 	if attribute == "% Ability Critical Damage" then
@@ -935,7 +935,7 @@ COverthrowGameMode.HeroStatsData = {
     {"hpe", 0.1, " % Total Health", "Vitality", "Vital", "Vitality"}, 
     {"map", 0.1, " % Total Mana", "Deep", "Deep", "Depth"}, 
     --crit procs
-    {"abc", 0.05, " % Ability Crit (200%)", "Executioner", "Final", "Execution"}, --weapons, shoulder, ring
+    {"abc", 0.05, " % Ability Crit (300%)", "Executioner", "Final", "Execution"}, --weapons, shoulder, ring
     {"abd", 0.025, " % Ability Crit (1000%)", "Cataclysm", "Cataclysmic", "Cataclysm"}, --weapons, shoulder, ring
     {"aac", 0.025, " % Auto Attack Crit (300%)", "Deadly", "Deadly", "Conflict"}, --weapons
     {"aae", 0.05, " % Auto Attack Crit (300%)", "Piercer", "Piercing", "Piercing"} --weapons
@@ -950,7 +950,7 @@ COverthrowGameMode.GeneratedItemData = {
     {"spp", " Spellpower", "Wizard", "Mythical", "Magic"}, 
     {"crd", "% Ability Critical Damage", "Colossal", "Cruel", "Destruction"}, --offhand, ring
     {"ats", " Attack Speed", "Windfury", "Rapid", "Combat"}, --weapons, shoulder
-    {"abc", "% Ability Crit (200%)", "Executioner", "Final", "Execution"}, --weapons, shoulder, ring
+    {"abc", "% Ability Crit (300%)", "Executioner", "Final", "Execution"}, --weapons, shoulder, ring
     {"arm", " Armor", "Valyrian", "Unbreakable", "Defense"}, --not weapons and ring
     {"res", " Spell Resistance", "Barrier", "Enchanted", "Shelter"}, --not weapons and ring
     {"aac", "% Auto Attack Crit (300%)", "Deadly", "Deadly", "Conflict"}, --weapons


### PR DESCRIPTION
https://docs.google.com/document/d/1IjueGgnfucSWfs8QILzK2R5YfoHRK6b9Zyj6_wvBYDU/edit

(description in progress)

Artifacts math to not lost it:
0.11 ab crit multiplier
0.25 ab dmg multiplier

35-45 immo arti levels
50-75 divine arti levels
80-90 myth arti levels

2 stats: 11-100 rolls

3 stats: 4-100 rolls

0,25 * 100 = 25 = 0,69 = 52% ab dmg (best possible roll for myth?)
0,11 * 100 = 11 = 0,30 = 22,91% x3 ab crit (best possible roll for myth?)
