### PR TITLE
Removed armor cap

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -8079,7 +8079,7 @@
 		"DOTA_Tooltip_ability_item_pathbuff_050_Description"  "<font color=\"#FF6600\">+3 for the Path Talent Swipe of Ursa.</font>"
 		"DOTA_Tooltip_ability_item_pathbuff_050_stat1"  "Strength: "
 		"DOTA_Tooltip_ability_item_pathbuff_051"  "<font color=\"#ffd700\">[Divine] Mammoth Cuirass"
-		"DOTA_Tooltip_ability_item_pathbuff_051_Description"  "<font color=\"#FF6600\">+3 for the Path Talent Steel Mammoth.</font>\nTotal Armor cap increased from 150 to 175."
+		"DOTA_Tooltip_ability_item_pathbuff_051_Description"  "<font color=\"#FF6600\">+3 for the Path Talent Steel Mammoth.</font>"
 		"DOTA_Tooltip_ability_item_pathbuff_051_stat1"  "Primary Attribute: "
 		"DOTA_Tooltip_ability_item_pathbuff_051_stat2"  "Armor: "
 		"DOTA_Tooltip_ability_item_pathbuff_052"  "<font color=\"#ffd700\">[Divine] Assassin's Longbow"

--- a/game/scripts/npc/npc_items_custom.txt
+++ b/game/scripts/npc/npc_items_custom.txt
@@ -18183,7 +18183,7 @@
 		}
 		"01"{
 			"var_type"      "FIELD_INTEGER"
-			"stat2"    "10"
+			"stat2"    "25"
 		}
 	}
 	"Modifiers"

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -20278,7 +20278,7 @@ function PassiveStatCalculation(event)
     --hero:RemoveModifierByName("modifier_agi_custom")
     hero:RemoveModifierByName("modifier_agi_custom_penalty")
     hero:RemoveModifierByName("modifier_str_custom_penalty")
-    hero:RemoveModifierByName("modifier_armor_custom_penalty")
+    --hero:RemoveModifierByName("modifier_armor_custom_penalty")
     --hero:RemoveModifierByName("modifier_dmg_from_primary")
     --hero:RemoveModifierByName("modifier_aa_from_abi")
     local system_aacrit_stacks = 0
@@ -20929,15 +20929,15 @@ function PassiveStatCalculation(event)
     realBaseStatsToApply[AA] = realBaseStats[AA] - hero:GetAttackDamage()
 
     --armor cap 150
-    local armorCap = 150
-    if hero:HasModifier("modifier_pathbuff_051") then
-        armorCap = 175
-    end
-    if realBaseStats[ARM] > armorCap then
-        local buff = "modifier_armor_custom_penalty"
-        ability:ApplyDataDrivenModifier(hero, hero, buff, {Duration = dur})
-        hero:SetModifierStackCount(buff, ability, realBaseStats[ARM] - armorCap)
-    end
+    --local armorCap = 150
+    --if hero:HasModifier("modifier_pathbuff_051") then
+    --    armorCap = 175
+    --end
+    --if realBaseStats[ARM] > armorCap then
+    --    local buff = "modifier_armor_custom_penalty"
+    --    ability:ApplyDataDrivenModifier(hero, hero, buff, {Duration = dur})
+    --    hero:SetModifierStackCount(buff, ability, realBaseStats[ARM] - armorCap)
+    --end
 
     --now we have calculated all basic stats, lets apply them!
     for i = 4, totalAttributes do --str int agi already applied


### PR DESCRIPTION
In 7.27 they reverted armor formula to very first one that requires insane values like 99999 armor for physical damage immunity so cap now pointless and indirectly nerf armor related path talents on top of that. I also changed steel mammoth divine armor from 10 to 25 to somewhat compensate lost effect
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/96af652f-8e5b-4a23-987f-0aeab4b88548)

Damage test with 6000 armor (100 dmg per hit from ml500 30k aa dmg wolf)
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/74f92764-bca8-4b36-a09c-d51e1b30b26b)
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/8ed369c5-501e-429b-8e5c-3584ecd8db43)

