### PR TITLE
Calculate max health bonus per lvl correctly

### DIFF
--- a/content/panorama/layout/custom_game/eloranking.xml
+++ b/content/panorama/layout/custom_game/eloranking.xml
@@ -1582,7 +1582,8 @@
 				<Label class="ButtTextBigGold" text="They are based on the last Ability Damage Instance\nyou caused right before the snapshot happens." style="color:white; font-size: 16px; horizontal-align: left;"/>
 				<Label class="ButtTextBigGold" text="Cooldown Reduction considers the last Ability\ncast before the snapshot happens." style="color:white; font-size: 16px; horizontal-align: left;"/>
 				<Label class="ButtTextBigGold" text="Hero Attributes Information" style="font-size: 24px;"/>
-				<Label class="ButtTextBigGold" text="The default DotA stats are altered in Titanbreaker.\nYou can find details when hovering over your main stats UI.\n\nMelee Heroes start with 30 Spell Resistance (not Healers)\n+50 Health per Hero Level" style="font-size: 16px; horizontal-align: left; color:white;"/>
+				<Label class="ButtTextBigGold" text="The default DotA stats are altered in Titanbreaker.\nYou can find details when hovering over your main stats UI.\n\nMelee Heroes start with 30 Spell Resistance (not Healers)" style="font-size: 16px; horizontal-align: left; color:white;"/>
+				<Label id="MaxHealthPerLvlLabel" class="ButtTextBigGold" text="+(LOADING) Max Health per Hero Level" style="font-size: 16px; horizontal-align: left; color:white;"/>
 				<Label class="ButtTextBigGold" text="There are 2 effects that modify the Damage of Abilities\non a percentage basis: % Damage and % Elemental\nDamage(Fire, Frost, Arcane, Physical...). % Damage\nfrom any sourcestacks multiplicatively,\nwhile % Elemental Damage stacks additively." style="color:white; font-size: 16px; horizontal-align: left;"/>
 				<Label class="ButtTextBigGold" text="Ability Damage can also be affected by non-percentage based\nElemental Damage. For example + 10 Fire Damage causes\neach Fire Damage instance to add 10 Damage to its base\nDamage, ignoring the scaling of the Ability but receiving\nother Bonuses." style="color:white; font-size: 16px; horizontal-align: left;"/>
 				<!--Label class="ButtTextBigGold" text="Attack Power increases the Damage\nfor Strength and Agility Heroes.\nSpellpower increases the\nDamage of Intellect Heroes." style="color:white; font-size: 16px; horizontal-align: left;"/-->
@@ -1590,7 +1591,7 @@
 				<Label class="ButtTextBigGold" text="Effects that modify Critical Strike Chances\nand Damage stack additively." style="color:white; font-size: 16px; horizontal-align: left;"/>
 				<Label class="ButtTextBigGold" text="Spell Resistance from Artifacts is capped at 35." style="color:white; font-size: 16px; horizontal-align: left;"/>
 				<Label class="ButtTextBigGold" text="Percentage Bonuses from multiple Artifacts\nstack additively (for example +5% Damage and\n+10% Damage results in +15% Damage)." style="color:white; font-size: 16px; horizontal-align: left;"/>
-				<Label class="ButtTextBigGold" text="Spellhaste increases the tick rate of Channeled Abilities\nbut only up to 200%." style="color:white; font-size: 16px; horizontal-align: left;"/>
+				<Label id="ChannelSpellHasteLabel" class="ButtTextBigGold" text="Spellhaste increases the tick rate of Channeled Abilities\nbut only up to (LOADING) %." style="color:white; font-size: 16px; horizontal-align: left;"/>
 				<Label class="ButtTextBigGold" text="When you have more than 1 core Healer (Divine Crusader /\nHoly Cleric / Twilight Cleric / Peaceful Guardian / Spirit Voodoo)\nin your party, there will be a Healing output penalty\nfor all players:" style="color:white; font-size: 16px; horizontal-align: left;"/>
 				<Label class="ButtTextBigGold" text="2 Healers = 25% Output" style="color:white; font-size: 16px; horizontal-align: left;"/>
 				<Label class="ButtTextBigGold" text="3 Healers = 10% Output" style="color:white; font-size: 16px; horizontal-align: left;"/>

--- a/content/panorama/scripts/custom_game/eloranking.js
+++ b/content/panorama/scripts/custom_game/eloranking.js
@@ -4593,6 +4593,14 @@ function OpenDiscordURL()
     $.DispatchEvent("ExternalBrowserGoToURL", $.GetContextPanel(), "https://discord.gg/as8MzdJ");
 }
 
+function OnHeroStatsValuesResponse(args)
+{
+    let hpPerLevel = args["bonusMaxHpPerLvl"].toFixed();
+    let channelSpellhasteCap = ((args["channelSpellhasteCap"]-1)*100).toFixed();
+    $("#ChannelSpellHasteLabel").text = "Spellhaste increases the tick rate of Channeled Abilities\nbut only up to " + channelSpellhasteCap + "%.";
+    $("#MaxHealthPerLvlLabel").text = "+" + hpPerLevel + " Max Health per Hero Level";
+}
+
 (function () {
     //$.Msg("Elo StatCollection Client Loaded");
 
@@ -4639,6 +4647,7 @@ function OpenDiscordURL()
     GameEvents.Subscribe("additemstoshop", AddItemsToShop);
     GameEvents.Subscribe("getautosellresponse", OnAutoSellFiltersResponse);
     GameEvents.Subscribe("getleaderboardresponse", OnLeaderboardResponseFromServer);
+    GameEvents.Subscribe("getherostatsvaluesresponse", OnHeroStatsValuesResponse);
 
     //Game.AddCommand( "+UPressed", ToggleInventory, "", 0 );
     //Game.AddCommand( "+OPressed", ToggleTalentTree, "", 0 );

--- a/game/scripts/vscripts/addon_game_mode.lua
+++ b/game/scripts/vscripts/addon_game_mode.lua
@@ -2695,11 +2695,27 @@ function COverthrowGameMode:OnPlayerConnected(params)
     -- Restore talents data for that client
     SendAllTalentsToPlayer(player, playerId)
     -- Restore toggle stash button
-    COverthrowGameMode:SendStashInfo(player)
-
+    COverthrowGameMode:SendStashInfo(player, playerId)
+    -- Update hero stats window values to match actual ones
+    COverthrowGameMode:SendHeroStatsInfo(player, playerId)
+    
     -- Allows next reconnect requests spam
     COverthrowGameMode._ignoreReconnectRequestsFromPlayer[playerId] = nil
   end)
+end
+
+function COverthrowGameMode:SendHeroStatsInfo(player, playerId)
+  local hero = PlayerResource:GetSelectedHeroEntity(playerId)
+
+  if(hero == nil) then
+    return
+  end
+
+  CustomGameEventManager:Send_ServerToPlayer(player, "getherostatsvaluesresponse",
+  {
+    channelSpellhasteCap = GetChannelSpellhasteCap(hero),
+    bonusMaxHpPerLvl = GetMaxHpBonusPerHeroLevel(hero)
+  })
 end
 
 function COverthrowGameMode:SendStashInfo(player)

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -19737,7 +19737,7 @@ function GetAttackSpeedBonus( hero, armor, strength, agility )
 end
 
 function GetHealthStaticBonus( hero, strength, agility, intellect, armor, magicres, maxMana )
-    local static_bonus = 25 * (hero:GetLevel() - 1) + 200 --bugged, must use getherolevel here but would lead to op hp in lategame
+    local static_bonus = (GetMaxHpBonusPerHeroLevel(hero) * GetHeroLevel(hero))
     if hero.talents[120] and hero.talents[120] > 0 then
         static_bonus = static_bonus + 0.1 * hero.talents[120] * maxMana
     end
@@ -20113,6 +20113,10 @@ end
 function GetRequiredAttackRangeBonuses( hero )
     local bonus = GetInterstellarStat(hero)
     return bonus
+end
+
+function GetMaxHpBonusPerHeroLevel(hero)
+    return 25
 end
 
 function GetMaxHpBonusFromStr(hero, str)

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -20115,10 +20115,12 @@ function GetRequiredAttackRangeBonuses( hero )
     return bonus
 end
 
+-- Be aware that this also called once per connection from panorama to display right value in hero stats window
 function GetMaxHpBonusPerHeroLevel(hero)
     return 25
 end
 
+-- Be aware that this also called over time from panorama to display right value in hero stats tooltip
 function GetMaxHpBonusFromStr(hero, str)
     local hpPerStr = 10
     if hero.talents[3] and hero.talents[3] > 0 then
@@ -20128,18 +20130,22 @@ function GetMaxHpBonusFromStr(hero, str)
     return str * hpPerStr
 end
 
+-- Be aware that this also called over time from panorama to display right value in hero stats tooltip
 function GetPhysicalDamageBonusFromStr(hero, str)
     return 0.001 * str --0.0008 
 end
 
+-- Be aware that this also called over time from panorama to display right value in hero stats tooltip
 function GetAttackSpeedBonusFromAgi(hero, agility)
     return 0.05 * agility
 end
 
+-- Be aware that this also called over time from panorama to display right value in hero stats tooltip
 function GetArmorBonusFromAgi(hero, agility)
     return 0.04 * agility
 end
 
+-- Be aware that this also called over time from panorama to display right value in hero stats tooltip
 function GetCriticalStrikeDamageBonusFromAgi(hero, agility)
     local extra = 0
     if hero.talents[116] > 0 then
@@ -20148,6 +20154,7 @@ function GetCriticalStrikeDamageBonusFromAgi(hero, agility)
     return (0.0005 + extra) * agility
 end
 
+-- Be aware that this also called over time from panorama to display right value in hero stats tooltip
 function GetMaxManaBonusFromInt(hero, int)
     local manaPerInt = 1 --10 --12
     if hero.resourcesystem then
@@ -20156,10 +20163,12 @@ function GetMaxManaBonusFromInt(hero, int)
     return manaPerInt * int
 end
 
+-- Be aware that this also called over time from panorama to display right value in hero stats tooltip
 function GetAbilityDamageBonusFromInt(hero, int)
     return 0.00015 * GetIntellectCustom(hero)
 end
 
+-- Be aware that this also called over time from panorama to display right value in hero stats tooltip
 function GetSpellResistanceBonusFromInt(hero, int)
     local mresPerInt = 0.01
     if GetLevelOfAbility(hero, "ench3") >= 4 then
@@ -27934,6 +27943,7 @@ function ChannelTickSystem( event )
     end
 end
 
+-- Be aware that this called once per connection from panorama to display right value in hero stats window
 function GetChannelSpellhasteCap( caster )
     local cap = 3 --2
     --if caster:HasModifier("modifier_wing") or caster:HasModifier("modifier_wing2") then


### PR DESCRIPTION
- Correct max hp bonus per lvl calculation
Without stats per lvl fix and this change (2.7k hp):
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/05c3e80e-d6fb-4c82-9bc4-7cb9711137c7)
With stats per lvl fix and this change (5.1k hp):
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/c412578f-5448-44c4-b5eb-18c6bc3032aa)
- Loads this values from server so they will be always up to date (they was already not match actual ones)
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/b0037b81-cf5e-4f05-813c-d8393b4b669b)


