### PR TITLE
UI related changes/fixes

### DIFF
--- a/content/panorama/layout/custom_game/dota_hud/dota_buff.xml
+++ b/content/panorama/layout/custom_game/dota_hud/dota_buff.xml
@@ -6,7 +6,7 @@
 	<Panel class="DOTABuff" hittest="true" >
 		<Button class="BuffBorder">
 			<DOTAAbilityImage id="BuffImageDefault" abilityname="rubick_empty1" scaling="stretch-to-fit-y-preserve-aspect"/>
-			<DOTAItemImage id="BuffItemImage" abilityname="rubick_empty1" scaling="stretch-to-fit-y-preserve-aspect"/>
+			<DOTAItemImage id="BuffItemImage" scaling="stretch-to-fit-y-preserve-aspect"/>
 			<Image id="BuffImage" scaling="stretch-to-fit-y-preserve-aspect"/>
 			<Panel id="CircularDuration" />
 			<Label id="StackCount" text="0" />

--- a/content/panorama/layout/custom_game/dota_hud/dota_buff.xml
+++ b/content/panorama/layout/custom_game/dota_hud/dota_buff.xml
@@ -6,6 +6,7 @@
 	<Panel class="DOTABuff" hittest="true" >
 		<Button class="BuffBorder">
 			<DOTAAbilityImage id="BuffImageDefault" abilityname="rubick_empty1" scaling="stretch-to-fit-y-preserve-aspect"/>
+			<DOTAItemImage id="BuffItemImage" abilityname="rubick_empty1" scaling="stretch-to-fit-y-preserve-aspect"/>
 			<Image id="BuffImage" scaling="stretch-to-fit-y-preserve-aspect"/>
 			<Panel id="CircularDuration" />
 			<Label id="StackCount" text="0" />

--- a/content/panorama/layout/custom_game/titanbreaker_scoreboard_top_player.xml
+++ b/content/panorama/layout/custom_game/titanbreaker_scoreboard_top_player.xml
@@ -20,7 +20,8 @@
 			<Image hittest="false" id="DisconnectionIndicator" src="s2r://panorama/images/custom_game/icon_disconnect_png.vtex" />
 		</Panel>
 		<Panel hittest="false" id="LivesContainer">
-			<Panel hittest="false" id="LivesBG"/>
+			<Image id="LivesImage" scaling="stretch-to-fit-y-preserve-aspect" src="s2r://panorama/images/spellicons/pangolier_heartpiercer.png"/>
+			<Panel id="LivesBorder" />
 			<Label id="LivesLabel" text="5"/>
 		</Panel>
 		<Button id="TipButton" class="DotaPlusDarkButton" visibility="colalpse">

--- a/content/panorama/layout/custom_game/titanbreaker_scoreboard_top_team.xml
+++ b/content/panorama/layout/custom_game/titanbreaker_scoreboard_top_team.xml
@@ -3,17 +3,18 @@
 		<include src="s2r://panorama/styles/dotastyles.vcss_c" />
         <include src="file://{resources}/styles/custom_game/titanbreaker_scoreboard_top.css" />
 	</styles>
-	<Panel hittest="false" class="ScoreboardTeamWrapper">
+	<scripts>
+        <include src="file://{resources}/scripts/custom_game/titanbreaker_scoreboard_top_team.js" />
+	</scripts>
+	<Panel hittest="false" class="ScoreboardTeamWrapper" hittestchildren="true">
 		<Panel hittest="false" id="ScoreboardTeam">
-			<Panel id="LocalTeamOverlay"/>
-			<Panel hittest="false" id="PlayersContainer" style="visibility: visible;"/>
-			<Panel hittest="false" id="TeamOverlayBar" style="visibility: collapse;">
-				<Panel hittest="false" id="TeamDarkenWash" />
+			<Panel id="LocalTeamOverlay" hittest="false"/>
+			<Panel hittest="false" id="TeamOverlayBar" style="visibility: visible;">
 				<Panel hittest="false" id="LogoAndScore">
-					<Panel hittest="false" id="TeamLogo" />
-					<Label hittest="false" id="TeamScore" text="999" />
+					<Label hittest="true" id="IngameTime" text="00:00" onactivate="OnIngameTimeClicked()"/>
 				</Panel>
 			</Panel>
+			<Panel hittest="false" id="PlayersContainer" style="visibility: visible;"/>
 		</Panel>
 		<Panel hittest="false" id="TeamOverlayXMLFile" />
 	</Panel>

--- a/content/panorama/scripts/custom_game/dota_hud/dota_buff_list.js
+++ b/content/panorama/scripts/custom_game/dota_hud/dota_buff_list.js
@@ -69,7 +69,9 @@ function UpdateBuffPanel(panel, selectedUnit, buffSerial)
     let isItem = Abilities.IsItem(buffAbility);
     let isCustomIcon = textureName.indexOf("fix/") !== -1;
     let pathToIcon = "";
-    
+        
+    panel.SetHasClass("is_item", false);
+
     if(isCustomIcon) {
         if(isItem) {
             textureName = textureName.replace("item_", "");
@@ -78,8 +80,10 @@ function UpdateBuffPanel(panel, selectedUnit, buffSerial)
             pathToIcon = "raw://resource/flash3/images/spellicons/" + textureName + ".png";
         }
     } else {
-        if(isItem) {
-            textureName = textureName.replace("item_", "");
+        if(isItem && textureName.indexOf("item_") !== -1) {
+            panel.SetHasClass("is_item", true);
+            panel._itemImagePanel.itemname = Abilities.GetAbilityName(buffAbility);
+            //textureName = textureName.replace("item_", "");
         }
         pathToIcon = "file://{images}/spellicons/" + textureName + ".png";
     }
@@ -116,6 +120,7 @@ function InitializeChildrens(panel, isBuffs)
         buffPanel.SetHasClass("is_undispellable", true); // looks better with it and no way to get this at panorama...
         buffPanel.BLoadLayout('file://{resources}/layout/custom_game/dota_hud/dota_buff.xml', false, false);
         buffPanel._imagePanel = buffPanel.FindChildTraverse("BuffImage");
+        buffPanel._itemImagePanel = buffPanel.FindChildTraverse("BuffItemImage");
         buffPanel._stacksLabel = buffPanel.FindChildTraverse("StackCount");
         buffPanel._durationPanel = buffPanel.FindChildTraverse("CircularDuration");
         buffPanel._queryUnit = -1;

--- a/content/panorama/scripts/custom_game/eloranking.js
+++ b/content/panorama/scripts/custom_game/eloranking.js
@@ -3938,6 +3938,7 @@ function SetMainStats(args)
     main_stats[id][13] = args.resourceType;
     main_stats[id][14] = args.spellHaste;
     main_stats[id][15] = args.damageReduction;
+    main_stats[id][16] = args.attackSpeed;
 }
 
 let customXpContainer = undefined;
@@ -3969,6 +3970,8 @@ let manaRegenLabel = undefined;
 let customBuffsContainer = undefined;
 let customDebuffsContainer = undefined;
 let customGoldLabel = undefined;
+let customAttackSpeedLabel = undefined;
+let customAttackSpeedUnitStatsLabel = undefined;
 
 function OnTooltipVisible(object) {
     if(object.paneltype != "DOTATooltipUnitDamageArmor") {
@@ -4010,6 +4013,25 @@ function InjectIntoDotaHeroStatsTooltip()
     customIntModifierStatsLabel = dotaHudRoot.FindChildTraverse("BonusIntelligenceLabel");
     customIntBonusLabel = dotaHudRoot.FindChildTraverse("IntelligenceDetails");
     customIntPrimaryBonusLabel = dotaHudRoot.FindChildTraverse("IntelligenceDamageLabel");
+
+    // Adds custom attack speed row to unit stats tooltip
+    let attackContainer = dotaHudRoot.FindChildTraverse("AttackContainer");
+    if(attackContainer != undefined) {
+        if(attackContainer._customAttackSpeedLabel == undefined) {
+            let dotaAttackSpeedLabel = attackContainer.FindChildTraverse("AttackSpeed");
+            if(dotaAttackSpeedLabel != undefined) {
+                dotaAttackSpeedLabel.style.visibility = "collapse";
+
+                let dotaAttackSpeedLabelParent = dotaAttackSpeedLabel.GetParent();
+                let customAttackSpeedRowLabel = $.CreatePanel("Label", dotaAttackSpeedLabelParent, '');
+                customAttackSpeedRowLabel.SetHasClass("BaseValue", true);
+                dotaAttackSpeedLabelParent.MoveChildAfter(customAttackSpeedRowLabel, dotaAttackSpeedLabel);
+                attackContainer._customAttackSpeedLabel = customAttackSpeedRowLabel;
+            }
+        }
+    }
+
+    customAttackSpeedUnitStatsLabel = attackContainer._customAttackSpeedLabel;
 
     // Adds custom spell haste row to unit stats tooltip
     let manaRegenRow = dotaHudRoot.FindChildTraverse("ManaRegenRow");
@@ -4101,6 +4123,15 @@ function UpdateMainStatsUI(selectedPlayerUnit, isUnitStatsTooltip)
         customStrAgiIntContainer.SetHasClass("ShowStrAgiInt", isHero);
     }
 
+    let selectedUnitAttackSpeed = 0;
+    if(isHero) {
+        // Heroes attack speed can go over cap for attack speed based effects so we display it instead of dota provided attack speed
+        selectedUnitAttackSpeed = main_stats[selectedHeroPlayerID][16].toFixed(0);
+    } else
+    {
+        selectedUnitAttackSpeed = (Entities.GetAttackSpeed(selectedPlayerUnit) * 100).toFixed(0);
+    }
+
     // Update str/agi/int
     if(isHero) {
         let str = main_stats[selectedHeroPlayerID][0].toFixed();
@@ -4126,46 +4157,76 @@ function UpdateMainStatsUI(selectedPlayerUnit, isUnitStatsTooltip)
         if(isUnitStatsTooltip != undefined) {
             if(customStrStatsLabel != undefined) {
                 customStrStatsLabel.text = str;
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change str value in unit stats tooltip).");
             }
     
             if(customStrModifierStatsLabel != undefined) {
                 customStrModifierStatsLabel.text = "";
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change str modifier value in unit stats tooltip).");
             }
     
             if(customStrBonusLabel != undefined) {
                 let totalPhysDmg = (main_stats[selectedHeroPlayerID][6] * 100).toFixed(1);
                 customStrBonusLabel.text = "= " + main_stats[selectedHeroPlayerID][5].toFixed() + " Max Health and " + totalPhysDmg + "% Physical Damage";
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change str bonuses label in unit stats tooltip).");
             }
     
             if(customStrPrimaryBonusLabel != undefined) {
                 customStrPrimaryBonusLabel.text = "";
                 customStrPrimaryBonusLabel.style.visibility = "collapse";
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change str primary bonus label in unit stats tooltip).");
             }
     
             if(customAgiStatsLabel != undefined) {
                 customAgiStatsLabel.text = agi;
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change agi value label in unit stats tooltip).");
             }
     
             if(customAgiModifierStatsLabel != undefined) {
                 customAgiModifierStatsLabel.text = "";
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change agi modifier label in unit stats tooltip).");
             }
     
             if(customAgiBonusLabel != undefined) {
                 let totalCritDmg = (main_stats[selectedHeroPlayerID][9] * 100).toFixed(1)
                 customAgiBonusLabel.text = "= " + main_stats[selectedHeroPlayerID][7].toFixed(0) + " Attack Speed, " + main_stats[selectedHeroPlayerID][8].toFixed(0) + " Armor and " + totalCritDmg + "% Critical Strike Damage";
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change agi bonuses label in unit stats tooltip).");
             }
     
             if(customAgiPrimaryBonusLabel != undefined) {
                 customAgiPrimaryBonusLabel.text = "";
                 customAgiPrimaryBonusLabel.style.visibility = "collapse";
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change agi primary bonuses label in unit stats tooltip).");
             }
     
             if(customIntStatsLabel != undefined) {
                 customIntStatsLabel.text = int;
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change int value label in unit stats tooltip).");
             }
     
             if(customIntModifierStatsLabel != undefined) {
                 customIntModifierStatsLabel.text = "";
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change int modifier label in unit stats tooltip).");
             }
     
             if(customIntBonusLabel != undefined) {
@@ -4180,13 +4241,37 @@ function UpdateMainStatsUI(selectedPlayerUnit, isUnitStatsTooltip)
                 }
 
                 customIntBonusLabel.text = intDetails;
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change int bonuses label in unit stats tooltip).");
             }
     
             if(customIntPrimaryBonusLabel != undefined) {
                 customIntPrimaryBonusLabel.text = "";
                 customIntPrimaryBonusLabel.style.visibility = "collapse";
+            } else
+            {
+                $.Msg("Valve break something or did major changes to UI (can't change int primary bonuses label in unit stats tooltip).");
             }
         }
+    }
+    
+    // Update attack speed label in hero stats tooltip
+    if(isUnitStatsTooltip != undefined) {
+        if(customAttackSpeedUnitStatsLabel != undefined) {
+            customAttackSpeedUnitStatsLabel.text = selectedUnitAttackSpeed;
+        } else
+        {
+           $.Msg("Valve break something or did major changes to UI (can't change attack speed label in unit stats tooltip).");
+        }
+    }
+    
+    // Update attack speed label in hero stats region
+    if(customAttackSpeedLabel != undefined) {
+        customAttackSpeedLabel.text = selectedUnitAttackSpeed;
+    } else
+    {
+       $.Msg("Valve break something or did major changes to UI (can't change attack speed label in hero stats region).");
     }
 
     // Update unit stats spellhaste row
@@ -4513,6 +4598,12 @@ function InjectIntoDotaUI()
             }
         }
     }
+    
+    // Attack speed label
+    let statsRegion = dotaHudRoot.FindChildTraverse("stats");
+    if(statsRegion != undefined) {
+        customAttackSpeedLabel = dotaHudRoot.FindChildTraverse("AttackSpeedLabelBase");
+    }
 }
 
 function SetUIStats(args)
@@ -4723,7 +4814,7 @@ function OnHeroStatsValuesResponse(args)
     runeword_id = new Array(20);
     pathword = new Array(10);
     pathword_id = new Array(10);
-    main_stats = new Array(15);
+    main_stats = new Array(10);
     gold_stat = new Array(10);
     //talents
     talents = new Array(10);
@@ -4739,8 +4830,8 @@ function OnHeroStatsValuesResponse(args)
             main_stats[i][j] = 0;
         }
         */
-        main_stats[i] = new Array(5);
-        for (var j = 0; j < 15; j++) {
+        main_stats[i] = new Array(16);
+        for (var j = 0; j <= 16; j++) {
             main_stats[i][j] = 0;
         }
     }

--- a/content/panorama/scripts/custom_game/titanbreaker_scoreboard_top.js
+++ b/content/panorama/scripts/custom_game/titanbreaker_scoreboard_top.js
@@ -204,6 +204,25 @@ function _ScoreboardUpdater_UpdatePlayerPanel(scoreboardConfig, playersContainer
     _ScoreboardUpdater_SetTextSafe(playerPanel, "PlayerUltimateCooldown", ultStateOrTime);
 }
 
+function FormatIngameTime(duration)
+{   
+    // Hours, minutes and seconds
+    var hrs = ~~(duration / 3600);
+    var mins = ~~((duration % 3600) / 60);
+    var secs = ~~duration % 60;
+
+    // Output like "1:01" or "4:03:59" or "123:03:59"
+    var ret = "";
+
+    if (hrs > 0) {
+        ret += "" + hrs + ":" + (mins < 10 ? "0" : "");
+    }
+
+    ret += "" + mins + ":" + (secs < 10 ? "0" : "");
+    ret += "" + secs;
+    return ret;
+}
+
 //=============================================================================
 //=============================================================================
 function _ScoreboardUpdater_UpdateTeamPanel(scoreboardConfig, containerPanel, teamDetails, teamsInfo) {
@@ -254,8 +273,9 @@ function _ScoreboardUpdater_UpdateTeamPanel(scoreboardConfig, containerPanel, te
         teamsInfo.max_team_players = teamPlayers.length;
     }
 
-    _ScoreboardUpdater_SetTextSafe(teamPanel, "TeamScore", teamDetails.team_score);
-    _ScoreboardUpdater_SetTextSafe(teamPanel, "TeamName", $.Localize(teamDetails.team_name));
+
+    _ScoreboardUpdater_SetTextSafe(teamPanel, "IngameTime", FormatIngameTime(Game.GetDOTATime(false, false)));
+    //_ScoreboardUpdater_SetTextSafe(teamPanel, "TeamName", $.Localize(teamDetails.team_name));
 
     if (GameUI.CustomUIConfig().team_colors) {
         var teamColor = GameUI.CustomUIConfig().team_colors[teamId];

--- a/content/panorama/scripts/custom_game/titanbreaker_scoreboard_top_player.js
+++ b/content/panorama/scripts/custom_game/titanbreaker_scoreboard_top_player.js
@@ -1,4 +1,5 @@
 let LIVES_LABEL = undefined;
+let LIVES_CONTAINER = undefined;
 
 function PortraitClicked() {
     Players.PlayerPortraitClicked($.GetContextPanel().GetAttributeInt("player_id", -1), GameUI.IsControlDown(), GameUI.IsAltDown());
@@ -29,15 +30,18 @@ function AutoUpdateLivesLabel()
     if(playerId > -1 && LIVES_LABEL != undefined) {
         let totalLives = GetLivesAmount(playerId);
         LIVES_LABEL.text = totalLives;
-        LIVES_LABEL.SetHasClass("Hidden", totalLives == 0);
+        if(LIVES_CONTAINER != undefined) {
+            LIVES_CONTAINER.SetHasClass("Hidden", totalLives == 0);
+        }
     }
 
-    $.Schedule(1, function() {
+    $.Schedule(0.25, function() {
         AutoUpdateLivesLabel();
     })
 }
 
 (function() {
-    LIVES_LABEL = $.GetContextPanel().FindChildTraverse("LivesLabel")
+    LIVES_LABEL = $.GetContextPanel().FindChildTraverse("LivesLabel");
+    LIVES_CONTAINER = $.GetContextPanel().FindChildTraverse("LivesContainer");
     AutoUpdateLivesLabel();
 })();

--- a/content/panorama/scripts/custom_game/titanbreaker_scoreboard_top_team.js
+++ b/content/panorama/scripts/custom_game/titanbreaker_scoreboard_top_team.js
@@ -1,0 +1,4 @@
+function OnIngameTimeClicked()
+{
+    $.DispatchEvent("DOTAGameTimeClicked");
+}

--- a/content/panorama/styles/custom_game/dota_hud/dota_buff.css
+++ b/content/panorama/styles/custom_game/dota_hud/dota_buff.css
@@ -49,7 +49,7 @@
     visibility: visible;
 }
 
-#BuffImage, #BuffImageDefault {
+#BuffImage, #BuffImageDefault, #BuffItemImage {
     margin-left: 2px;
     margin-right: 2px;
     margin-top: 2px;
@@ -59,6 +59,21 @@
     border-radius: 50%;
     box-shadow: inset #000000aa 0px 1px 16px 1px;
     border: 1px solid black;
+}
+
+#BuffItemImage
+{
+    visibility: collapse;
+}
+
+.is_item #BuffImage
+{
+    visibility: collapse;
+}
+
+.is_item #BuffItemImage
+{
+    visibility: visible;
 }
 
 #AbilityImage {

--- a/content/panorama/styles/custom_game/titanbreaker_scoreboard_top.css
+++ b/content/panorama/styles/custom_game/titanbreaker_scoreboard_top.css
@@ -42,13 +42,6 @@
     margin-right: M_EXTRA_PADDING;
 }
 
-#TeamLogo {
-    horizontal-align: left;
-    vertical-align: top;
-    width: 24px;
-    height: 24px;
-}
-
 .ScoreboardTeamWrapper.no_players {
     visibility: collapse;
 }
@@ -115,24 +108,20 @@
 #LogoAndScore {
     height: 100%;
     width: 64px;
+    horizontal-align: center;
 }
 
-#TeamScore {
+#IngameTime {
     vertical-align: bottom;
-    horizontal-align: left;
+    horizontal-align: center;
     color: white;
-    font-size: 24px;
+    font-size: 14px;
     font-weight: bold;
     text-shadow: 4px 4px 4px black;
     margin-bottom: 4px;
     margin-left: 1px;
     text-overflow: clip;
-}
-
-#TeamDarkenWash {
-    width: 100%;
-    height: 42px;
-    background-color: gradient(linear, 25px 0%, 40px 0%, from(black), to(transparent));
+    padding-left: 24px;
 }
 
 #TeamStatus {
@@ -147,7 +136,7 @@
 
 #TeamOverlayBar {
     width: 100%;
-    height: 48px;
+    height: 77px;
 }
 
 #LocalTeamOverlay {
@@ -315,18 +304,13 @@
 }
 
 #LivesContainer {
-    horizontal-align: right;
-    width: 20px;
-    height: 20px;
-    margin-top: 25px;
+    horizontal-align: center;
+    width: 28px;
+    height: 28px;
+    margin-top: 30px;
     visibility: visible;
     margin-right: 0px;
-}
-
-#LivesBG {
-    background-image: none;
-    width: 32px;
-    height: 32px;
+    opacity: 1;
 }
 
 #LivesLabel
@@ -342,9 +326,54 @@
     background-color: gradient( radial, 50% 100%, 0% 0%, 50% 100%, from( #000000ee ), to( #00000009 ) );
 }
 
-#LivesLabel.Hidden
+.player_dead #LivesContainer,
+.Hidden #LivesContainer
 {
     visibility: collapse;
+}
+
+.LivesBorder {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    box-shadow: fill #00000099 0px 0px 4px 0px;
+}
+
+#LivesLabel {
+    width: 100%;
+    max-height: 16px;
+    text-shadow: 0px 0px 2px 2 #000000;
+    color: white;
+    margin: 0px;
+    horizontal-align: center;
+    vertical-align: center;
+    font-family: monospaceNumbersFont;
+    font-size: 16px;
+    text-align: center;
+    text-overflow: shrink;
+}
+
+#LivesBorder {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    background-image: url("s2r://panorama/images/hud/reborn/buff_outline_psd.vtex");
+    background-size: 95% 95%;
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
+    wash-color: #8bdd4f;
+}
+
+#LivesImage {
+    margin-left: 2px;
+    margin-right: 2px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    box-shadow: inset #000000aa 0px 1px 16px 1px;
+    border: 1px solid black;
 }
 
 .RespawnSkullIcon

--- a/content/panorama/styles/custom_game/titanbreaker_scoreboard_top.css
+++ b/content/panorama/styles/custom_game/titanbreaker_scoreboard_top.css
@@ -108,20 +108,19 @@
 #LogoAndScore {
     height: 100%;
     width: 64px;
-    horizontal-align: center;
+    horizontal-align: left;
+    background-color: gradient( linear, 0% 0%, 100% 0%, from( #25282a00 ), color-stop( .6, #25282acc), color-stop( .8, #25282a88), to( #00000022 ) );
 }
 
 #IngameTime {
-    vertical-align: bottom;
+    vertical-align: center;
     horizontal-align: center;
     color: white;
     font-size: 14px;
     font-weight: bold;
     text-shadow: 4px 4px 4px black;
-    margin-bottom: 4px;
-    margin-left: 1px;
     text-overflow: clip;
-    padding-left: 24px;
+    padding-top: 6px;
 }
 
 #TeamStatus {
@@ -136,7 +135,8 @@
 
 #TeamOverlayBar {
     width: 100%;
-    height: 77px;
+    height: 42px;
+    margin-left: -25px;
 }
 
 #LocalTeamOverlay {

--- a/game/scripts/npc/npc_heroes_custom.txt
+++ b/game/scripts/npc/npc_heroes_custom.txt
@@ -5,6 +5,7 @@
 // FOR FUTURE REFERENCE:
 // In order to disable facet hero key here must be unique and not match dota one (npc_dota_hero_riki_titanbreaker) + empty facets block
 // In order to disable innate abilities replace every unused slot with generic_hidden to override valve kv innate ability (be aware of 32 abilities cap that you may reach because valve adding abilities during runtime)
+// If new hero will be ever added set his "BaseAttackSpeed" to 100 to prevent random dota patch break attack speed calculation for certain heroes
 
 "DOTAHeroes"
 {
@@ -34,6 +35,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 
 		"UnitLabel"         "hero"
 
@@ -115,6 +119,9 @@
 		{
 		}
 
+		"BaseAttackSpeed"		"100"
+		
+
 		"UnitLabel"         "hero"
 
 		//"AttackRate"				"1000"
@@ -193,6 +200,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 
 		"UnitLabel"         "hero"
 
@@ -274,6 +284,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 
 		"UnitLabel"         "hero"
 
@@ -357,6 +370,9 @@
 		{
 		}
 
+		"BaseAttackSpeed"		"100"
+		
+
 		"UnitLabel"         "hero"
 
 		"ModelScale"				"0.78"
@@ -436,6 +452,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 
 		"UnitLabel"         "hero"
 
@@ -518,6 +537,9 @@
 		{
 		}
 
+		"BaseAttackSpeed"		"100"
+		
+
 		"UnitLabel"         "hero"
 
 		//"AttackRate"				"1000"
@@ -597,6 +619,9 @@
 		{
 		}
 
+		"BaseAttackSpeed"		"100"
+		
+
 		"UnitLabel"         "hero"
 
 		//"AttackRate"				"1000"
@@ -674,6 +699,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 
 		"UnitLabel"         "hero"
 		"ModelScale"				"0.66"
@@ -753,6 +781,9 @@
 		{
 		}
 
+		"BaseAttackSpeed"		"100"
+		
+
 		"UnitLabel"         "hero"
 		"ModelScale"				"0.66"
 		//"AttackRate"				"1000"
@@ -830,6 +861,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 
 		"UnitLabel"         "hero"
 
@@ -912,6 +946,9 @@
 		{
 		}
 
+		"BaseAttackSpeed"		"100"
+		
+
 		"UnitLabel"         "hero"
 
 
@@ -992,6 +1029,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 
 		"UnitLabel"         "hero"
 
@@ -1074,6 +1114,9 @@
 		{
 		}
 
+		"BaseAttackSpeed"		"100"
+		
+
 		"UnitLabel"         "hero"
 
 
@@ -1155,6 +1198,9 @@
 		{
 		}
 
+		"BaseAttackSpeed"		"100"
+		
+
 		"UnitLabel"         "hero"
 
 		//"AttackRate"				"1000"
@@ -1232,6 +1278,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 
 		"UnitLabel"         "hero"
 
@@ -1311,6 +1360,9 @@
 		{
 		}
 
+		"BaseAttackSpeed"		"100"
+		
+
 		"UnitLabel"         "hero"
 
 		//"AttackRate"				"1000"
@@ -1387,6 +1439,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -1464,6 +1519,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -1542,6 +1600,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -1619,6 +1680,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -1696,6 +1760,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"ModelScale"				"0.94"
 
@@ -1778,6 +1845,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -1856,6 +1926,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -1933,6 +2006,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2010,6 +2086,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2090,6 +2169,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2168,6 +2250,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2238,6 +2323,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2317,6 +2405,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2396,6 +2487,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 		"ModelScale"				"0.9"
@@ -2475,6 +2569,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 		"ModelScale"				"0.8"
@@ -2554,6 +2651,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2635,6 +2735,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2714,6 +2817,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2793,6 +2899,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2877,6 +2986,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -2956,6 +3068,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -3036,6 +3151,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -3120,6 +3238,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"ModelScale"				"0.94"
 
@@ -3202,6 +3323,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -3277,6 +3401,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 		"ModelScale"				"1.1"
@@ -3357,6 +3484,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -3440,6 +3570,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"UnitLabel"         "hero"
 
@@ -3519,6 +3652,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"ModelScale"				"0.80"
 
@@ -3606,6 +3742,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"ModelScale"				"1.00"
 
@@ -3693,6 +3832,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"ModelScale"				"1.00"
 
@@ -3780,6 +3922,9 @@
 		"Facets"
 		{
 		}
+
+		"BaseAttackSpeed"		"100"
+		
 		
 		"ModelScale"				"0.90"
 

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -20915,7 +20915,8 @@ function PassiveStatCalculation(event)
     realBaseStats[ARM] = baseStats[ARM] * baseStatsPercentFactor[ARM]
     realBaseStatsToApply[ARM] = realBaseStats[ARM] - hero:GetPhysicalArmorValue(false)
     --AS
-    local passiveASBonus = hero:GetAttackSpeed(true) * 100 - 100
+    local baseAttackSpeed = 100 -- 100 is base attack speed that will be hardcoded for now because very unlikely this will be ever changed in tb (since some dota patch some heroes have different base attack speed)
+    local passiveASBonus = hero:GetAttackSpeed(true) * 100 - baseAttackSpeed
     baseStats[AS] = GetAttackSpeedBonus(hero, realBaseStats[ARM], realBaseStats[STR], realBaseStats[AGI]) + passiveASBonus   --100 base AS are given but in fact theyre not doing anything
     baseStatsPercentFactor[AS] = 1
     realBaseStats[AS] = baseStats[AS] * baseStatsPercentFactor[AS]
@@ -20963,7 +20964,8 @@ function PassiveStatCalculation(event)
         spellResistanceFromInt = GetSpellResistanceBonusFromInt(hero, realBaseStats[INT]),
         resourceType = hero.resourcesystem,
         spellHaste = GetSpellhaste(hero, { caster = hero, target = hero, ability = nil }),
-        damageReduction = GetTotalDamageTakenFactor(hero, nil)
+        damageReduction = GetTotalDamageTakenFactor(hero, nil),
+        attackSpeed = realBaseStats[AS] + baseAttackSpeed
     })
 
     --now we have calculated all basic stats, lets apply them!


### PR DESCRIPTION
* Improved top bar. Added more obvious indication that counter = lives amount and game time label (clickable with alt)
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/cedbaf49-c3a6-471d-82ee-72a4bdfb3bb5)
* Added "BaseAttackSpeed" kv property to every hero entry so now every hero will 100% have 100 base attack speed (since some dota patch certain heroes have greater/lower base attack speed than 100)
* Fixed attack speed display (now it displays attack speed value calculated at lua side for heroes)
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/89858a0a-938b-4af7-82bf-b9c8d65f45f0)
* Fixed most/all item modifiers icons. This approach should work for every item, but may break for something special
From
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/01c1b0fc-d549-47dd-9f53-911a08793bdf)
To
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/be96bf5d-55a9-425e-ab43-49eda3d32cff)