### PR TITLE
Removed base attack speed from stats tooltip (less confusing)

### DIFF
--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -21394,7 +21394,7 @@ function PassiveStatCalculation(event)
             resourceType = hero.resourcesystem,
             spellHaste = GetSpellhaste(hero, { caster = hero, target = hero, ability = nil }),
             damageReduction = GetTotalDamageTakenFactor(hero, nil),
-            attackSpeed = realBaseStats[AS] + baseAttackSpeed
+            attackSpeed = realBaseStats[AS]
         })
     end
 


### PR DESCRIPTION
This already caused at least one bug report stating that wings of liberty provide bonus at 600 attack speed instead of 500