### PR TITLE
Tweaked shadow fiend and splitting worms

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -8839,7 +8839,7 @@
 		"DOTA_Tooltip_ability_pve_wave_caller_2_Description"                              "Summon seismic shocks, moving from one side to the other and back, dealing high Arcane Damage."
 
 		"DOTA_Tooltip_ability_pve_temple_add_keep_close"                                  "Shadow Fiend"
-		"DOTA_Tooltip_ability_pve_temple_add_keep_close_Description"                      "Summon an unkillable Shadow Fiend, haunting the target with the lowest Aggro, dealing high Damage. When the Shadow Fiend is pulled further than 600 yards away from its Master, the Master enrages and gains bonus Attack Speed."
+		"DOTA_Tooltip_ability_pve_temple_add_keep_close_Description"                      "Summon an unkillable Shadow Fiend, haunting the target with the lowest Aggro, dealing high Damage. When the Shadow Fiend is pulled further than 600 yards away from its Master, the Master enrages and gains bonus Attack Speed.\nWhen you are the only Hero in the game, the Shadow Fiend is greatly slowed."
 		"DOTA_Tooltip_ability_pve_temple_add_keep_close_duration"                         "DURATION:"
 		"npc_dota_creature_shadow_creeper_pve"	"Shadow Fiend"
 

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -10461,7 +10461,7 @@
 		"DOTA_Tooltip_ability_pve_frostfire_chains_Description"                    "Chain up to 3 Heroes together, dealing Damage over time.\nThe Fire Chain extinguishes when both affected Heroes are farther than 2000 yards away from each other.\nThe Frost Chain breaks when the both affected Heroes are closer than 200 yards to each other."
 		
 		"DOTA_Tooltip_ability_pve_trap_hydra_2"                                             "Spitting Splitting Worm"
-		"DOTA_Tooltip_ability_pve_trap_hydra_2_Description"                                 "Summon a Worm lasting 15 secs, spitting dodgeable Poison Balls towards random Heroes, dealing high Nature Damage.\nWhen killed, the Worm splits into 2 Worms."
+		"DOTA_Tooltip_ability_pve_trap_hydra_2_Description"                                 "Summon a Worm lasting %duration% secs, spitting dodgeable Poison Ball towards random Hero, dealing high Nature Damage.\nWhen killed, the Worm splits into 2 Worms."
 
 		"DOTA_Tooltip_ability_pve_hellgate"                                             "Hellgate"
 		"DOTA_Tooltip_ability_pve_hellgate_Description"                                 "Open a Hellgate for 20 secs, launching Corrupted Coils at its Master, Healing allies and Damaging enemies in its path.\nWhen the Hellgate gets destroyed, 5 dangerous Infernals will spawn."

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -89351,6 +89351,11 @@
 						"Target" 		"TARGET"
 						"Duration"		"2"
 					}
+					"RunScript"
+					{
+						"ScriptFile"	"game_mechanics.lua"
+						"Function"		"KeepCloseSinglePlayerFriendly"
+					}
 				}
 			}
 			"FireSound"
@@ -89371,6 +89376,16 @@
         		"Properties"
         		{
         			"MODIFIER_PROPERTY_ATTACKSPEED_BONUS_CONSTANT" "300"
+        		}
+        	}
+        	"modifier_slow_keep_close_solo"
+        	{
+        		"IsHidden"			"1"
+        		"IsDebuff"			"1"
+        	
+        		"Properties"
+        		{
+        			"MODIFIER_PROPERTY_MOVESPEED_BONUS_CONSTANT" "-550"
         		}
         	}
         }

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -2792,12 +2792,13 @@
 						"Function"		"TempleRandomBuff"
 						"buff"		"modifier_shoot_missile_random"
 					}
-					"RunScript"
-					{
-						"ScriptFile"	"addon_game_mode.lua"
-						"Function"		"TempleRandomBuff"
-						"buff"		"modifier_shoot_missile_random"
-					}
+					// One missle per splitting worm attack for now
+					//"RunScript"
+					//{
+					//	"ScriptFile"	"addon_game_mode.lua"
+					//	"Function"		"TempleRandomBuff"
+					//	"buff"		"modifier_shoot_missile_random"
+					//}
         		}
 	        }
 	        "modifier_shoot_missile_random"
@@ -2907,7 +2908,7 @@
 						"UnitName"			"temple_missile_trap_hydra_2"
 						"Target"			"CASTER"
 						"UnitCount"			"1"
-						"Duration"			"15"
+						"Duration"			"17"
 						"SpawnRadius"		"?400 400"
 						"GrantsGold"		"0"
 						"GrantsXP"			"0"
@@ -2917,8 +2918,9 @@
 							"RunScript"
 				        	{
 				        		"ScriptFile"	"game_mechanics.lua"
-				        		"Function"		"AddAbilityToUnit"
+				        		"Function"		"AddAbilityToUnitDelayed"
 				        		"abil"	"pve_passive_random_missiles"
+								"delay"	"2" // delay attacks to give ppl time to react
 				        	}
 							"RunScript"
 							{

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -2872,7 +2872,7 @@
 	    	"01"
 	    	{
 	    		"var_type"			"FIELD_INTEGER"
-	    		"duration"			"14.75"
+	    		"duration"			"17"
 	    	}
 	    	"01"
 	    	{
@@ -2908,7 +2908,7 @@
 						"UnitName"			"temple_missile_trap_hydra_2"
 						"Target"			"CASTER"
 						"UnitCount"			"1"
-						"Duration"			"17"
+						"Duration"			"%duration"
 						"SpawnRadius"		"?400 400"
 						"GrantsGold"		"0"
 						"GrantsXP"			"0"

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -22059,6 +22059,12 @@ function AddAbilityToUnit(event)
     end
 end
 
+function AddAbilityToUnitDelayed(event)
+    Timers:CreateTimer(event.delay, function()
+        AddAbilityToUnit(event)
+    end)
+end
+
 function SetModelForModel(event)
     local caster = event.target
     caster:SetModel(event.model)

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -30966,3 +30966,11 @@ function GetCriticalStrikeDamageBonus(caster, dmgType, event, isAutoAttack)
 
     return value
 end
+
+function KeepCloseSinglePlayerFriendly(event)
+    local caster = event.target
+    local heroes = HeroList:GetAllHeroes()
+    if(#heroes == 1) then
+        event.ability:ApplyDataDrivenModifier(event.target, event.target, "modifier_slow_keep_close_solo", nil)
+    end
+end


### PR DESCRIPTION
- Added great slow (-550 ms) for shadow fiend in solo lobbies
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/8f3b3f9c-6784-414a-b67a-756fbf93868d)
- Added 2s delay and reduced projectiles per attack from 2 to 1 for splitting worm
![image](https://github.com/Catzee/Titanbreaker/assets/61186758/4257be34-5772-40d4-8f7c-05b4d970157a)
