### PR TITLE
Fixed ability:GetManaCost calls

### DIFF
--- a/game/scripts/vscripts/game_mechanics - kopie.lua
+++ b/game/scripts/vscripts/game_mechanics - kopie.lua
@@ -5777,7 +5777,7 @@ function Bookoflight(event)
 	local caster = event.caster
 	local a = event.event_ability
 	if a then
-		if a:GetManaCost(a:GetLevel()) > 0.0 then
+		if a:GetManaCost(-1) > 0.0 then
 			Timers:CreateTimer(0.05,function() 
 	        	caster:SetMana(caster:GetMana()+4)
 	    	end)

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -4582,7 +4582,7 @@ function GetAbilityDamageModifierMultiplicative( event, caster, real_caster, tar
         end
         local overpower = GetOverpowerStat(caster)
         if overpower > 0 and wascrit then
-            multiplicative_bonus = multiplicative_bonus * (1 + ability:GetManaCost(ability:GetLevel()) * overpower / 10000)
+            multiplicative_bonus = multiplicative_bonus * (1 + ability:GetManaCost(-1) * overpower / 10000)
         end
         if caster.songIceFire1Cast and caster.talents and caster:GetAbilityByIndex(1) == ability and caster.talents[129] > 0 then
             if math.random(1,100) <= caster.talents[129] * 33.4 then
@@ -4670,7 +4670,7 @@ function GetAbilityDamageModifierMultiplicative( event, caster, real_caster, tar
     if GetCrusaderStat(caster) >= 1 then
         multiplicative_bonus = multiplicative_bonus * (1 + (GetHealingMultiplier(event, caster, ability, target, false, false, false) - 1) * 0.01 * GetCrusaderStat(caster))
     end
-    if GetNetherfusionStat(caster) >= 1 and ability and ability:GetManaCost(ability:GetLevel()) >= 30 then
+    if GetNetherfusionStat(caster) >= 1 and ability and ability:GetManaCost(-1) >= 30 then
         multiplicative_bonus = multiplicative_bonus * (1 + 0.01 * GetNetherfusionStat(caster))
     end
     if pure_dmg and wascrit and event.arcanedmg and GetStarCollapseStat(caster) >= 1 then
@@ -4736,10 +4736,10 @@ function GetAbilityDamageModifierMultiplicative( event, caster, real_caster, tar
         multiplicative_bonus = multiplicative_bonus * 1.25
     end
     if ability and caster:HasModifier("modifier_new8") then
-        multiplicative_bonus = multiplicative_bonus * (1 + 0.005 * ability:GetManaCost(ability:GetLevel()))
+        multiplicative_bonus = multiplicative_bonus * (1 + 0.005 * ability:GetManaCost(-1))
     end
     if ability and caster:HasModifier("modifier_new82") then
-        multiplicative_bonus = multiplicative_bonus * (1 + 0.01 * ability:GetManaCost(ability:GetLevel()))
+        multiplicative_bonus = multiplicative_bonus * (1 + 0.01 * ability:GetManaCost(-1))
     end
     if caster:HasModifier("modifier_windfury_path") then
         multiplicative_bonus = multiplicative_bonus * (1 + 0.05 * caster.talents[53])
@@ -7923,7 +7923,7 @@ function Bookoflight(event)
 	local a = event.event_ability
     local mana = event.mana
 	if a and not caster.resourcesystem then
-		if a:GetManaCost(a:GetLevel()) > 0.0 then
+		if a:GetManaCost(-1) > 0.0 then
 			Timers:CreateTimer(0.05,function() 
 	        	caster:SetMana(caster:GetMana()+mana)
 	    	end)
@@ -14691,7 +14691,7 @@ function GlobalOnAbilityExecuted( event )
             end
         end
     end
-    if GetManaRefundAmount(caster) >= 1 and ability and ability:GetManaCost(ability:GetLevel()) >= 1 then
+    if GetManaRefundAmount(caster) >= 1 and ability and ability:GetManaCost(-1) >= 1 then
         Timers:CreateTimer(0.05, function()
             RestoreResource({caster = caster, amount = GetManaRefundAmount(caster), flat = true})
         end)
@@ -27622,7 +27622,7 @@ function GetHealingMultiplier(event, caster, ability, target, process_procs, isa
     if GetNaturesHarmonyStat(caster) >= 1 and not wascrit then
         healing_bonus = healing_bonus + 0.01 * GetNaturesHarmonyStat(caster)
     end
-    if GetNetherfusionStat(caster) >= 1 and ability and ability:GetManaCost(ability:GetLevel()) >= 30 then
+    if GetNetherfusionStat(caster) >= 1 and ability and ability:GetManaCost(-1) >= 30 then
         healing_bonus = healing_bonus + 0.01 * GetNetherfusionStat(caster)
     end
     if GetSwiftMendingStat(caster) >= 1 then
@@ -27813,10 +27813,10 @@ function GetHealingMultiplier(event, caster, ability, target, process_procs, isa
     end
     
     if ability and caster:HasModifier("modifier_new8") then
-        healing_bonus = healing_bonus + 0.005 * ability:GetManaCost(ability:GetLevel())
+        healing_bonus = healing_bonus + 0.005 * ability:GetManaCost(-1)
     end
     if ability and caster:HasModifier("modifier_new82") then
-        healing_bonus = healing_bonus + 0.01 * ability:GetManaCost(ability:GetLevel())
+        healing_bonus = healing_bonus + 0.01 * ability:GetManaCost(-1)
     end
     
     if event.alwaysself ~= nil then
@@ -30184,7 +30184,7 @@ function CheckForFlurryProc(event)
     local target = event.target
     local ability = caster:GetAbilityByIndex(caster.flurryAbility)
     local mana = caster:GetMana()
-    local manacost = ability:GetManaCost(ability:GetLevel() - 1)
+    local manacost = ability:GetManaCost(-1)
 
     if mana < manacost * 2 or ability:GetLevel() <= 0 then
         return

--- a/game/scripts/vscripts/game_mechanics_backup_pre_additive.lua
+++ b/game/scripts/vscripts/game_mechanics_backup_pre_additive.lua
@@ -3608,7 +3608,7 @@ function Bookoflight(event)
 	local caster = event.caster
 	local a = event.event_ability
 	if a then
-		if a:GetManaCost(a:GetLevel()) > 0.0 then
+		if a:GetManaCost(-1) > 0.0 then
 			Timers:CreateTimer(0.05,function() 
 	        	caster:SetMana(caster:GetMana()+4)
 	    	end)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/01441a29-7900-4fe8-adae-7cd5d2c7949b)
GetManaCost is 0 index based and `ability:GetLevel()` returns actual level of ability (level 1 = 1)
Example for this ability:
![image](https://github.com/user-attachments/assets/9b9c2b9d-4367-4baf-8551-15afd81fe819)
`ability:GetManaCost(ability:GetLevel())` = 0
`ability:GetManaCost(-1)` = 30

Such code probably also sneaky nerfed/buffed idk how much manacost based effects