### PR TITLE
Fixed blood wolves scaling

### DIFF
--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -75138,8 +75138,8 @@
 					{
 					    "ScriptFile"    "game_mechanics.lua"
 					    "Function"      "PetSystem"
-					    "str"			"50"
-					    "agi"			"50"
+					    "str"			"100"
+					    "agi"			"100"
 					    "talentscale"	"46"
 						"runewordscale"	"11"
 						"companionbehavior"	"1"


### PR DESCRIPTION
Fixed blood wolves scaling. Its supposed to be 100% per lvl
![image](https://github.com/user-attachments/assets/60647ec9-2627-4e50-9998-31f84615ea50)
