### PR TITLE
Fixed path talents items not stacking with souls correctly

### DIFF
--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -21440,7 +21440,7 @@ function PassiveStatCalculation(event)
         local path_word_bonus = 0
         for k=1, 3 do
             if i == soul[k][1] then
-                soul_item_bonus = soul[k][2]
+                soul_item_bonus = soul_item_bonus + soul[k][2]
             end
         end
         local path_bonus_from_ring_given = 0


### PR DESCRIPTION
Soul bonuses doesn't consider path talent item bonuses and overwrites them...
After fix:
![image](https://github.com/user-attachments/assets/124ef3e3-6218-45a9-847d-a0414c31e48e)
Iron skin arena item (+1) + soul (+2) + divine (+3) + 3pp = 9
![image](https://github.com/user-attachments/assets/ec55c1ac-42f0-4de1-8032-8db2c5eae664)
Cyclops set (+2) + soul (+2)  = 4
![image](https://github.com/user-attachments/assets/54767a8c-f214-4c7c-aec9-1e27f6478a84)

