### PR TITLE
Fixed stance abilities bugs

### DIFF
--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -37057,6 +37057,7 @@
 				"IsDebuff"			"0"
 				"IsStunDebuff"		"0"
 				"IsHidden"	"0"
+				"RemoveOnDeath"		"0"
 		
 				"Properties"
 				{
@@ -37072,7 +37073,7 @@
 				"IsDebuff"			"0"
 				"IsStunDebuff"		"0"
 				"IsHidden"	"1"
-		
+
 				"Properties"
 				{
 					//"MODIFIER_PROPERTY_BASEDAMAGEOUTGOING_PERCENTAGE" "%aabonus"

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -45624,7 +45624,8 @@
 				"IsDebuff"			"0"
 				"IsStunDebuff"		"0"
 				"IsHidden"	"0"
-		
+				"RemoveOnDeath"		"0"
+
 				"Properties"
 				{
 					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonusarmor"
@@ -45641,7 +45642,8 @@
 				"IsDebuff"			"0"
 				"IsStunDebuff"		"0"
 				"IsHidden"	"0"
-		
+				"RemoveOnDeath"		"0"
+				
 				"Properties"
 				{
 					"MODIFIER_PROPERTY_PHYSICAL_ARMOR_BONUS" "%bonusarmor"


### PR DESCRIPTION
Beastmaster and dragon knight stance switch rely on modifier and this modifier removed on death...
- [x] Beastmaster
- [x] Dragon Knight
- [x] Shadowstalkers
- [x] Dazzle
- [x] Venge