### PR TITLE
Memesis -> Phychic Link

### DIFF
--- a/game/scripts/vscripts/items.lua
+++ b/game/scripts/vscripts/items.lua
@@ -1373,7 +1373,7 @@ COverthrowGameMode.PathTalentNames = {
 	"Savagery",
 	"Lycanthrope",
 	"Primal Power",
-	"Mimesis",
+	"Phychic Link",
 	"Nemesis",
 	"Genesis",
 	"Typhoon Thunder",


### PR DESCRIPTION
In https://github.com/Catzee/Titanbreaker/commit/f7b5e659ba770ed8064aba4fafeb1f55c0ed4dc5 you forgot also rename memesis in path talent names array. Seems works as intended without this change and bug only visual one