### PR TITLE
Fixed havoc hammer tooltip

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -10719,7 +10719,7 @@
 		"DOTA_Tooltip_ability_item_neutral_7"                                              "<font color=\"#e0b86c\">[Singularity] Annihilator"
 		"DOTA_Tooltip_ability_item_neutral_7_Description"                                  "All Damaging Ability and Auto Attack Critical Strike Chances you have are increased by a flat additive 10%%."
 		"DOTA_Tooltip_ability_item_neutral_8"                                              "<font color=\"#e0b86c\">[Singularity] Havoc Hammer"
-		"DOTA_Tooltip_ability_item_neutral_8_Description"                                  "+2 for the Path Talent Cataclysm"
+		"DOTA_Tooltip_ability_item_neutral_8_Description"                                  "+4 for the Path Talent Cataclysm"
 		"DOTA_Tooltip_ability_item_neutral_9"                                              "<font color=\"#e0b86c\">[Singularity] Quiver of Artemis"
 		"DOTA_Tooltip_ability_item_neutral_9_Description"                                  "Hysteria fires a total of 3 Auto Attacks."
 		"DOTA_Tooltip_ability_item_neutral_10"                                              "<font color=\"#e0b86c\">[Singularity] Butterfly Cape"

--- a/game/scripts/vscripts/game_mechanics.lua
+++ b/game/scripts/vscripts/game_mechanics.lua
@@ -30913,10 +30913,7 @@ function GetPathBonuses(hero, isUpdateTickEvery5secs)
         bonuses[127] = 1
     end
     if HeroHasNeutralItem(hero, "item_neutral_8") then
-        bonuses[128] = 2
-    end
-    if HeroHasNeutralItem(hero, "item_neutral_8") then
-        bonuses[128] = bonuses[128] + 2
+        bonuses[128] = 4
     end
     if HeroHasNeutralItem(hero, "item_neutral_13") then
         bonuses[131] = 1


### PR DESCRIPTION
No idea what was intention here. This either copy paste error or some weird code, but probably +4 cataclysm is fine
<img width="587" height="198" alt="image" src="https://github.com/user-attachments/assets/c33089b7-ade6-4b49-bf2c-3a9fa418ed85" />
