### PR TITLE
Fixed mindshatter not counted as aoe damage for last ds player

### DIFF
--- a/game/scripts/vscripts/abilities/heroes/shadow_cleric/mindshatter.lua
+++ b/game/scripts/vscripts/abilities/heroes/shadow_cleric/mindshatter.lua
@@ -145,7 +145,7 @@ function shadow11:OnProjectileHit_ExtraData(target, location, extraData)
             target._shadowClericShadow11InnerCd  = nil
         end)
     end
-
+    
     DamageUnit({
         caster = caster,
         target = target,
@@ -153,7 +153,8 @@ function shadow11:OnProjectileHit_ExtraData(target, location, extraData)
         damage = 0,
         spelldamagefactor = self:GetSpecialValueFor("spelldmg") * extraData.damageFactor,
         attributefactor = self:GetSpecialValueFor("dmgfromstat") * extraData.damageFactor,
-        shadowdmg = 1
+        shadowdmg = 1,
+        isaoe = 1
     })
     
     if(target._shadowClericShadow11SecondInnerCd == nil and self:GetLevel() >= 3) then


### PR DESCRIPTION
Its supposed to be aoe
<img width="490" height="1093" alt="image" src="https://github.com/user-attachments/assets/05f0fcc2-1b9e-49fd-a70c-9b645cfeb582" />