### PR TITLE
Fixed phased effect for path talents summons

### DIFF
--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -59773,11 +59773,11 @@
 								"random"	"1"
 								"dontface"	"1"
 							}
-							"ApplyModifier"
+							"RunScript"
 							{
-								"ModifierName"	"modifier_phased"
-								"Target"	"TARGET"
-								"Duration"	"15"
+								"ScriptFile"	"game_mechanics.lua"
+								"Function"	"AddPhasedToSummon"
+								"duration"	"15"
 							}
 							"ApplyModifier"
 							{

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -59709,11 +59709,11 @@
 								"ScriptFile"	"game_mechanics.lua"
 								"Function"	"BloodWolfHeal"
 							}
-							"ApplyModifier"
+							"RunScript"
 							{
-								"ModifierName"	"modifier_phased"
-								"Target"	"TARGET"
-								"Duration"	"15"
+								"ScriptFile"	"game_mechanics.lua"
+								"Function"	"AddPhasedToSummon"
+								"duration"	"15"
 							}
 							"ApplyModifier"
 							{

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -59846,11 +59846,11 @@
 								"random"	"1"
 								"dontface"	"1"
 							}
-							"ApplyModifier"
+							"RunScript"
 							{
-								"ModifierName"	"modifier_phased"
-								"Target"	"TARGET"
-								"Duration"	"15"
+								"ScriptFile"	"game_mechanics.lua"
+								"Function"	"AddPhasedToSummon"
+								"duration"	"15"
 							}
 							"ApplyModifier"
 							{
@@ -59896,11 +59896,11 @@
 								"random"	"1"
 								"dontface"	"1"
 							}
-							"ApplyModifier"
+							"RunScript"
 							{
-								"ModifierName"	"modifier_phased"
-								"Target"	"TARGET"
-								"Duration"	"15"
+								"ScriptFile"	"game_mechanics.lua"
+								"Function"	"AddPhasedToSummon"
+								"duration"	"15"
 							}
 							"ApplyModifier"
 							{


### PR DESCRIPTION
Datadriven seems completely broken now and not working anymore
There are 192 datadriven "modifier_phased" left, but they probably don't cause noticeable issues or unused/useless content (like uri summon for example)