### PR TITLE
Fixed 7.41a

### DIFF
--- a/game/scripts/npc/npc_abilities_override.txt
+++ b/game/scripts/npc/npc_abilities_override.txt
@@ -2730,4 +2730,10 @@
 	"item_infused_raindrop"	"REMOVE"
 	"item_tome_of_knowledge"	"REMOVE"
 	"item_faerie_fire"	"REMOVE"
+	"item_dragon_lance"	"REMOVE"
+	"item_recipe_dragon_lance"	"REMOVE"
+	"item_specialists_array"	"REMOVE"
+	"item_recipe_specialists_array"	"REMOVE"
+	"item_hydras_breath"	"REMOVE"
+	"item_recipe_hydras_breath"	"REMOVE"
 }


### PR DESCRIPTION
Now wr doesn't crash server anymore. Removed items are items from 7.41 patch that now causing crash for some reason if hero somehow reference them
<img width="565" height="179" alt="image" src="https://github.com/user-attachments/assets/9f039692-884d-4957-a74c-ab140f5f76f1" />